### PR TITLE
Make InMemorySink disposable to clear log events

### DIFF
--- a/SerilogSinksInMemory.sln
+++ b/SerilogSinksInMemory.sln
@@ -11,9 +11,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{056C07B9-C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.InMemory.Tests.Unit", "test\Serilog.Sinks.InMemory.Tests.Unit\Serilog.Sinks.InMemory.Tests.Unit.csproj", "{32BA2907-C3CD-4957-88EE-C64FA6CFC7E3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.InMemory.Assertions", "src\Serilog.Sinks.InMemory.Assertions\Serilog.Sinks.InMemory.Assertions.csproj", "{57388B94-C61A-48CA-B7B7-9E82233DB7ED}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.InMemory.Assertions", "src\Serilog.Sinks.InMemory.Assertions\Serilog.Sinks.InMemory.Assertions.csproj", "{57388B94-C61A-48CA-B7B7-9E82233DB7ED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.InMemory.Assertions.Tests.Unit", "test\Serilog.Sinks.InMemory.Assertions.Tests.Unit\Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj", "{B2B802A5-04A4-4844-8A3E-CCEC78101C1C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.InMemory.Assertions.Tests.Unit", "test\Serilog.Sinks.InMemory.Assertions.Tests.Unit\Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj", "{B2B802A5-04A4-4844-8A3E-CCEC78101C1C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{14ACDCFC-205B-4918-AABC-4E97E46D8BD5}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventsAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventsAssertions.cs
@@ -53,7 +53,7 @@ namespace Serilog.Sinks.InMemory.Assertions
 
         public LogEventsAssertions WithLevel(LogEventLevel level, string because = "", params object[] becauseArgs)
         {
-            var notMatched = Subject.Where(logEvent => logEvent.Level != level);
+            var notMatched = Subject.Where(logEvent => logEvent.Level != level).ToList();
 
             var notMatchedText = "";
 

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -6,10 +6,10 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <Title>Serilog in-memory sink assertion extensions</Title>
     <Description>FluentAssertions extensions to use with the Serilog.Sinks.InMemory package</Description>
-    <Copyright>2018 Sander van Vliet</Copyright>
+    <Copyright>2019 Sander van Vliet</Copyright>
     <Authors>Sander van Vliet</Authors>
     <PackageProjectUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/LICENSE</PackageLicenseUrl>

--- a/src/Serilog.Sinks.InMemory/InMemorySink.cs
+++ b/src/Serilog.Sinks.InMemory/InMemorySink.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using Serilog.Core;
 using Serilog.Events;
 
 namespace Serilog.Sinks.InMemory
 {
-    public class InMemorySink : ILogEventSink
+    public class InMemorySink : ILogEventSink, IDisposable
     {
         private static readonly AsyncLocal<InMemorySink> LocalInstance = new AsyncLocal<InMemorySink>();
 
@@ -34,6 +35,11 @@ namespace Serilog.Sinks.InMemory
         public void Emit(LogEvent logEvent)
         {
             _logEvents.Add(logEvent);
+        }
+
+        public void Dispose()
+        {
+            _logEvents.Clear();
         }
     }
 }

--- a/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
+++ b/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
@@ -6,10 +6,10 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Title>Serilog in-memory sink</Title>
     <Description>A sink to be used for testing log messages using Serilog</Description>
-    <Copyright>2018 Sander van Vliet</Copyright>
+    <Copyright>2019 Sander van Vliet</Copyright>
     <Authors>Sander van Vliet</Authors>
     <PackageProjectUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/LICENSE</PackageLicenseUrl>

--- a/test/Serilog.Sinks.InMemory.Tests.Unit/WhenLoggingToInMemorySink.cs
+++ b/test/Serilog.Sinks.InMemory.Tests.Unit/WhenLoggingToInMemorySink.cs
@@ -19,5 +19,41 @@ namespace Serilog.Sinks.InMemory.Tests.Unit
                 .Should()
                 .HaveCount(1);
         }
+
+        [Fact]
+        public void GivenLoggerIsDisposed_LogEventsAreCleared()
+        {
+            var logger = new LoggerConfiguration()
+                .WriteTo.InMemory()
+                .CreateLogger();
+
+            logger.Information("Test");
+
+            logger.Dispose();
+
+            InMemorySink.Instance
+                .LogEvents
+                .Should()
+                .HaveCount(0);
+        }
+
+        [Fact]
+        public void GivenLoggerIsDisposedAndNewMessageIsLogged_SinkOnlyContainsSecondMessage()
+        {
+            var logger = new LoggerConfiguration()
+                .WriteTo.InMemory()
+                .CreateLogger();
+
+            logger.Information("First");
+
+            logger.Dispose();
+
+            logger.Information("Second");
+
+            InMemorySink.Instance
+                .LogEvents
+                .Should()
+                .OnlyContain(l => l.MessageTemplate.Text == "Second");
+        }
     }
 }


### PR DESCRIPTION
This PR addresses issue #3 to allow disposing the logger to clear out all the log events that were previously sent to the sink.

Depending on your test framework and test setup this feature may come in handy when you want to reset the log events.

Consider for example MSTest:

```csharp
public class WhenDemonstratingDisposableFeature
{
    private Logger _logger;
    
    [TestInitialize]
    public void Initialize()
    {
        _logger?.Dispose();

        _logger = new LoggerConfiguration()
            .WriteTo.InMemory()
            .CreateLogger();
    }

    [TestMethod]
    public void GivenAFoo_BarIsBlah()
    {
        _logger.Information("Foo");

        InMemorySink.Instance
            .Should()
            .HaveMessage("Foo");
    }

    [TestMethod]
    public void GivenABar_BazIsQuux()
    {
        _logger.Information("Bar");

        InMemorySink.Instance
            .Should()
            .HaveMessage("Bar");
    }
}
```
this approach ensures that the `GivenABar_BazIsQuux` does not see any messages logged in a previous test.