### PR TITLE
Target net45 and switch to NUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Serilog.Sinks.InMemory
 In-memory sink for Serilog to use for testing with [FluentAssertions](https://fluentassertions.com/) support for easy to write assertions.
 
+Currently the package targets `net45` and `netstandard1.3`. When using this package in projects targeting `net45`/`net451`/`net452` please see [Clearing log events between tests](#clearing-log-events-between-tests) as the .Net versions &lt; `net462` have issues with isolating the `InMemorySink` instance between tests.
+
 ## Build status
 [![Build status](https://ci.appveyor.com/api/projects/status/aq0g2f247q5proix?svg=true)](https://ci.appveyor.com/project/sandermvanvliet/serilogsinksinmemory)
 [![NuGet Serilog.Sinks.InMemory](https://buildstats.info/nuget/Serilog.Sinks.InMemory)](https://www.nuget.org/packages/Serilog.Sinks.InMemory/)
@@ -178,19 +180,16 @@ This will fail with a message: `Expected instances of log message "Hello, world!
 
 ## Clearing log events between tests
 
-Depending on your test framework and test setup you may want to ensure that the log events captured by the `InMemorySink` are cleared so tests 
-are not interfering with eachother. To enable this, the `InMemorySink` implements the [`IDisposable`](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable?view=netstandard-2.0) interface. 
-When `Dispose()` is called the `LogEvents` collection is cleared. 
+Depending on your test framework and test setup you may want to ensure that the log events captured by the `InMemorySink` are cleared so tests are not interfering with eachother. To enable this, the `InMemorySink` implements the [`IDisposable`](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable?view=netstandard-2.0) interface. When `Dispose()` is called the `LogEvents` collection is cleared.
 
-It will depend on the test framework or your test if you need this feature. With xUnit this feature is not necessary as it isolates each test in its own instance of the test class which means that they all
-have their own instance of the `InMemorySink`. MSTest however has a different approach and there you may want to use this feature as follows:
+It will depend on the test framework or your test if you need this feature. With xUnit this feature is not necessary as it isolates each test in its own instance of the test class which means that they all have their own instance of the `InMemorySink`. MSTest however has a different approach and there you may want to use this feature as follows:
 
 ```csharp
 [TestClass]
 public class WhenDemonstratingDisposableFeature
 {
     private Logger _logger;
-    
+
     [TestInitialize]
     public void Initialize()
     {
@@ -222,4 +221,7 @@ public class WhenDemonstratingDisposableFeature
     }
 }
 ```
+
 this approach ensures that the `GivenABar_BazIsQuux` does not see any messages logged in a previous test.
+
+For NUnit you can use the `[TesrDown]` attribute for a similar approach.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,6 @@ before_build:
   - cmd: dotnet --version
   - cmd: dotnet restore --verbosity m
 build_script:
-  - cmd: dotnet publish ./src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
-  - cmd: dotnet publish ./src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
   - cmd: dotnet pack ./src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
   - cmd: dotnet pack ./src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
 after_build:

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -6,13 +6,13 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Version>0.4.1</Version>
+    <Version>0.5.0</Version>
     <Title>Serilog in-memory sink assertion extensions</Title>
     <Description>FluentAssertions extensions to use with the Serilog.Sinks.InMemory package</Description>
     <Copyright>2019 Sander van Vliet</Copyright>
     <Authors>Sander van Vliet</Authors>
     <PackageProjectUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/LICENSE</PackageLicenseUrl>
+    <PackageLicense>https://github.com/sandermvanvliet/SerilogSinksInMemory/LICENSE</PackageLicense>
     <RepositoryUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/src/Serilog.Sinks.InMemory/InMemorySink.cs
+++ b/src/Serilog.Sinks.InMemory/InMemorySink.cs
@@ -8,8 +8,13 @@ namespace Serilog.Sinks.InMemory
 {
     public class InMemorySink : ILogEventSink, IDisposable
     {
+#if NET45
+        // AsyncLocal<T> is introduced in net462 so we need to
+        // be satisfied with ThreadLocal<T> for net45*
+        private static readonly ThreadLocal<InMemorySink> LocalInstance = new ThreadLocal<InMemorySink>();
+#else
         private static readonly AsyncLocal<InMemorySink> LocalInstance = new AsyncLocal<InMemorySink>();
-
+#endif
         private readonly List<LogEvent> _logEvents;
 
         public InMemorySink()

--- a/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
+++ b/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
@@ -6,13 +6,13 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Version>0.3.0</Version>
+    <Version>0.5.0</Version>
     <Title>Serilog in-memory sink</Title>
     <Description>A sink to be used for testing log messages using Serilog</Description>
     <Copyright>2019 Sander van Vliet</Copyright>
     <Authors>Sander van Vliet</Authors>
     <PackageProjectUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/LICENSE</PackageLicenseUrl>
+    <PackageLicense>https://github.com/sandermvanvliet/SerilogSinksInMemory/LICENSE</PackageLicense>
     <RepositoryUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
+++ b/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;net462;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingLogEventsExist.cs
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingLogEventsExist.cs
@@ -1,13 +1,13 @@
 using System;
 using FluentAssertions;
-using Xunit;
-using Xunit.Sdk;
+using NUnit.Framework;
+using Serilog.Core;
 
 namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
 {
     public class WhenAssertingLogEventsExist
     {
-        private readonly ILogger _logger;
+        private readonly Logger _logger;
 
         public WhenAssertingLogEventsExist()
         {
@@ -16,7 +16,15 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
                 .CreateLogger();
         }
 
-        [Fact]
+        [TearDown]
+        public void TearDown()
+        {
+            // Instance isolation gets tricky with tests so we need to 
+            // ensure the sink is reset after each test.
+            _logger.Dispose();
+        }
+
+        [Test]
         public void GivenNoLogMessage_HaveMessageFails()
         {
             Action action = () => InMemorySink.Instance
@@ -25,11 +33,11 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
 
             action
                 .Should()
-                .Throw<XunitException>()
+                .Throw<Exception>()
                 .WithMessage("Expected message \"Hello, World\" to be logged");
         }
 
-        [Fact]
+        [Test]
         public void GivenSingleLogMessage_HaveMessagePasses()
         {
             _logger.Information("Hello, World");
@@ -39,7 +47,7 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
                 .HaveMessage("Hello, World");
         }
 
-        [Fact]
+        [Test]
         public void GivenTheSameLogMessageFourTimesAndAssertingOnlyOnce_HaveMessageFails()
         {
             _logger.Information("Hello, World");
@@ -54,11 +62,11 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
 
             action
                 .Should()
-                .Throw<XunitException>()
+                .Throw<Exception>()
                 .WithMessage("Expected message \"Hello, World\" to appear exactly once, but it was found 4 times");
         }
 
-        [Fact]
+        [Test]
         public void GivenTheSameLogMessageFourTimesAndAssertingFourTimes_HaveMessageSucceeds()
         {
             _logger.Information("Hello, World");
@@ -72,7 +80,7 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
                 .Appearing().Times(4);
         }
 
-        [Fact]
+        [Test]
         public void GivenTheSameLogMessageFourTimesAndAssertingFiveTimes_HaveMessageFails()
         {
             _logger.Information("Hello, World");
@@ -87,7 +95,7 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
 
             action
                 .Should()
-                .Throw<XunitException>()
+                .Throw<Exception>()
                 .WithMessage("Expected message \"Hello, World\" to appear 5 times, but it was found 4 times");
         }
     }

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingScalarLogPropertyExists.cs
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingScalarLogPropertyExists.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using FluentAssertions;
+using NUnit.Framework;
 using Serilog.Context;
-using Xunit;
-using Xunit.Sdk;
+using Serilog.Core;
 
 namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
 {
     public class WhenAssertingScalarLogPropertyExists
     {
-        private readonly ILogger _logger;
+        private readonly Logger _logger;
 
         public WhenAssertingScalarLogPropertyExists()
         {
@@ -18,7 +18,15 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
                 .CreateLogger();
         }
 
-        [Fact]
+        [TearDown]
+        public void TearDown()
+        {
+            // Instance isolation gets tricky with tests so we need to 
+            // ensure the sink is reset after each test.
+            _logger.Dispose();
+        }
+
+        [Test]
         public void GivenMessageIsLoggedWithProperty_HavePropertySucceeds()
         {
             _logger.Information("Hello {name}", "World");
@@ -30,7 +38,7 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
                 .WithProperty("name");
         }
 
-        [Fact]
+        [Test]
         public void GivenMessageIsLoggedWithoutProperty_HavePropertyFails()
         {
             _logger.Information("Hello {name}", "World");
@@ -43,11 +51,11 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
 
             action
                 .Should()
-                .Throw<XunitException>()
+                .Throw<Exception>()
                 .WithMessage("Expected message \"Hello {name}\" to have a property \"something else\" but it wasn't found");
         }
 
-        [Fact]
+        [Test]
         public void GivenMessageIsLoggedWithPropertyAndAssertingValue_HavePropertySucceeds()
         {
             _logger.Information("Hello {name}", "World");
@@ -60,7 +68,7 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
                 .WithValue("World");
         }
 
-        [Fact]
+        [Test]
         public void GivenMessageIsLoggedWithPropertyAndAssertingDifferentValue_HavePropertyFails()
         {
             _logger.Information("Hello {name}", "World");
@@ -74,11 +82,11 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
 
             action
                 .Should()
-                .Throw<XunitException>()
+                .Throw<Exception>()
                 .WithMessage("Expected property \"name\" to have value \"BLABLABLA\" but found \"World\"");
         }
 
-        [Fact]
+        [Test]
         public void GivenMessageIsLoggedWithIntegerPropertyValue_HavePropertySucceeds()
         {
             _logger.Information("Message number {number}", 5);
@@ -91,7 +99,7 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
                 .WithValue(5);
         }
 
-        [Fact]
+        [Test]
         public void GivenMessageIsLoggedWithIntegerPropertyAndAssertingDifferentValue_HavePropertyFails()
         {
             _logger.Information("Message number {number}", 5);
@@ -105,11 +113,11 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
 
             action
                 .Should()
-                .Throw<XunitException>()
+                .Throw<Exception>()
                 .WithMessage("Expected property \"number\" to have value 2 but found 5");
         }
 
-        [Fact]
+        [Test]
         public void GivenMessageIsLoggedWithPropertyFromContext_HavePropertySucceeds()
         {
             using (LogContext.PushProperty("some_property", "some_value"))

--- a/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;net462;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.InMemory.Tests.Unit/WhenConfiguringInMemorySink.cs
+++ b/test/Serilog.Sinks.InMemory.Tests.Unit/WhenConfiguringInMemorySink.cs
@@ -1,13 +1,13 @@
 ﻿using System.Reflection;
 using FluentAssertions;
+using NUnit.Framework;
 using Serilog.Core;
-using Xunit;
 
 namespace Serilog.Sinks.InMemory.Tests.Unit
 {
     public class WhenConfiguringInMemorySink
     {
-        [Fact]
+        [Test]
         public void GivenConfigurationToWriteToInMemorySink_InMemorySinkIsAddedToLogger()
         {
             var logger = new LoggerConfiguration()

--- a/test/Serilog.Sinks.InMemory.Tests.Unit/WhenLoggingToInMemorySink.cs
+++ b/test/Serilog.Sinks.InMemory.Tests.Unit/WhenLoggingToInMemorySink.cs
@@ -1,11 +1,11 @@
 ﻿using FluentAssertions;
-using Xunit;
+using NUnit.Framework;
 
 namespace Serilog.Sinks.InMemory.Tests.Unit
 {
     public class WhenLoggingToInMemorySink
     {
-        [Fact]
+        [Test]
         public void GivenInformationMessageIsWritten_LogEventIsStoredInSink()
         {
             var logger = new LoggerConfiguration()
@@ -20,7 +20,7 @@ namespace Serilog.Sinks.InMemory.Tests.Unit
                 .HaveCount(1);
         }
 
-        [Fact]
+        [Test]
         public void GivenLoggerIsDisposed_LogEventsAreCleared()
         {
             var logger = new LoggerConfiguration()
@@ -37,7 +37,7 @@ namespace Serilog.Sinks.InMemory.Tests.Unit
                 .HaveCount(0);
         }
 
-        [Fact]
+        [Test]
         public void GivenLoggerIsDisposedAndNewMessageIsLogged_SinkOnlyContainsSecondMessage()
         {
             var logger = new LoggerConfiguration()


### PR DESCRIPTION
This PR changes the minimum supported framework to `net45`. In order to make that possible the test framework was switched from xUnit to NUnit as the former has a lower bound of `net462` so that prevented the tests from running.

`net45` does not support `AsyncLocal<T>` so the sink has been switched to use `ThreadLocal<T>`. 

When using the sink for testing it is important that you add a tear-down step to call `Dispose()` on the logger to clear the `LogEvents` collection of the sink. This will prevent flaky tests due to the fact that test isolation in NUnit is per assembly and not test. (Though this is a problem for `net45` / `net462` mostly but your mileage may vary)