### PR TITLE
Assertion improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,51 @@ public void GivenLoopWithFiveItems_MessageIsLoggedFiveTimes()
 
 This will fail with a message: `Expected instances of log message "Hello, world!" to have level Information, but found 3 with level Warning`
 
+### Asserting messages with a pattern
+
+Instead of matching on the exact message you can also match on a certain pattern using the `Containing()` assertion:
+
+```csharp
+InMemorySink.Instance
+   .Should()
+   .HaveMessage()
+   .Containing("some pattern")
+   .Appearing().Once();
+```
+
+which matches on log messages:
+
+- `this is some pattern`
+- `some pattern in a message`
+- `this is some pattern in a message`
+
+### Asserting messages have been logged at all (or not!)
+
+When you want to assert that a message has been logged but don't care about what message you can do that with `HaveMessage` and `Appearing`:
+
+```csharp
+InMemorySink.Instance
+                .Should()
+                .HaveMessage()
+                .Appearing().Times(3); // Expect three messages to be logged
+```
+
+and of course the inverse is also possible when expecting no messages to be logged:
+
+```csharp
+InMemorySink.Instance
+                .Should()
+                .NotHaveMessage();
+```
+
+or that a specific message is not be logged
+
+```csharp
+InMemorySink.Instance
+                .Should()
+                .NotHaveMessage("a specific message");
+```
+
 ## Clearing log events between tests
 
 Depending on your test framework and test setup you may want to ensure that the log events captured by the `InMemorySink` are cleared so tests

--- a/src/Serilog.Sinks.InMemory.Assertions/InMemorySinkAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/InMemorySinkAssertions.cs
@@ -4,7 +4,7 @@ using FluentAssertions.Primitives;
 
 namespace Serilog.Sinks.InMemory.Assertions
 {
-    public class InMemorySinkAssertions  : ReferenceTypeAssertions<InMemorySink, InMemorySinkAssertions>
+    public class InMemorySinkAssertions : ReferenceTypeAssertions<InMemorySink, InMemorySinkAssertions>
     {
         public InMemorySinkAssertions(InMemorySink instance)
         {
@@ -39,18 +39,34 @@ namespace Serilog.Sinks.InMemory.Assertions
         }
 
         public void NotHaveMessage(
-            string messageTemplate,
+            string messageTemplate = null,
             string because = "",
             params object[] becauseArgs)
         {
-            var count = Subject
+            int count;
+            string failureMessage;
+
+            if (messageTemplate != null)
+            {
+                count = Subject
                 .LogEvents
                 .Count(logEvent => logEvent.MessageTemplate.Text == messageTemplate);
+                
+                failureMessage = $"Expected message \"{messageTemplate}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
+            }
+            else
+            {
+                count = Subject
+                    .LogEvents
+                    .Count();
+
+                failureMessage = $"Expected no messages to be logged, but found {(count > 1 ? $"{count} messages" : "message")}";
+            }
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(count == 0)
-                .FailWith($"Expected message \"{messageTemplate}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}");  
+                .FailWith(failureMessage);
         }
     }
 }

--- a/src/Serilog.Sinks.InMemory.Assertions/InMemorySinkAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/InMemorySinkAssertions.cs
@@ -32,5 +32,25 @@ namespace Serilog.Sinks.InMemory.Assertions
 
             return new LogEventsAssertions(messageTemplate, matches);
         }
+
+        public PatternLogEventsAssertions HaveMessage()
+        {
+            return new PatternLogEventsAssertions(Subject.LogEvents);
+        }
+
+        public void NotHaveMessage(
+            string messageTemplate,
+            string because = "",
+            params object[] becauseArgs)
+        {
+            var count = Subject
+                .LogEvents
+                .Count(logEvent => logEvent.MessageTemplate.Text == messageTemplate);
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(count == 0)
+                .FailWith($"Expected message \"{messageTemplate}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}");  
+        }
     }
 }

--- a/src/Serilog.Sinks.InMemory.Assertions/PatternLogEventsAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/PatternLogEventsAssertions.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions.Execution;
+using Serilog.Events;
+
+namespace Serilog.Sinks.InMemory.Assertions
+{
+    public class PatternLogEventsAssertions : LogEventsAssertions
+    {
+        public PatternLogEventsAssertions(IEnumerable<LogEvent> subjectLogEvents) : base(null, subjectLogEvents)
+        {
+        }
+
+        public LogEventsAssertions Containing(
+            string pattern,
+            string because = "",
+            params object[] becauseArgs)
+        {
+            var matches = Subject
+                .Where(logEvent => logEvent.MessageTemplate.Text.Contains(pattern))
+                .ToList();
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(matches.Any())
+                .FailWith(
+                    "Expected a message with pattern {0} to be logged",
+                    pattern);
+
+            return new LogEventsAssertions(pattern, matches);
+        }
+    }
+}

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -23,7 +23,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.*" />
-    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.*">
+    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.*" />
+    <PackageReference Include="Serilog" Version="2.*">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -6,10 +6,10 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Version>0.4.1</Version>
+    <Version>0.6.0</Version>
     <Title>Serilog in-memory sink assertion extensions</Title>
     <Description>FluentAssertions extensions to use with the Serilog.Sinks.InMemory package</Description>
-    <Copyright>2019 Sander van Vliet</Copyright>
+    <Copyright>2020 Sander van Vliet</Copyright>
     <Authors>Sander van Vliet</Authors>
     <PackageProjectUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/LICENSE</PackageLicenseUrl>
@@ -23,10 +23,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.*" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Serilog.Sinks.InMemory\Serilog.Sinks.InMemory.csproj" />
+    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.*">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
+++ b/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
     <Title>Serilog in-memory sink</Title>
     <Description>A sink to be used for testing log messages using Serilog</Description>
     <Copyright>2020 Sander van Vliet</Copyright>
@@ -22,7 +22,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog" Version="2.*">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
+++ b/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
@@ -22,9 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.*">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Serilog" Version="2.*" />
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingLogEventsExist.cs
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingLogEventsExist.cs
@@ -90,5 +90,37 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
                 .Throw<XunitException>()
                 .WithMessage("Expected message \"Hello, World\" to appear 5 times, but it was found 4 times");
         }
+
+        [Fact]
+        public void GivenMessageExistsAndTestingForAbsence_AssertionFails()
+        {
+            _logger.Information("Hello, World");
+
+            Action action = () => InMemorySink.Instance
+                .Should()
+                .NotHaveMessage("Hello, World");
+
+            action
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage("Expected message \"Hello, World\" not to be logged, but it was found once");
+        }
+
+        [Fact]
+        public void GivenMessageExistsMultipleTImesAndTestingForAbsence_AssertionFailsWithAppearanceCountInFailure()
+        {
+            _logger.Information("Hello, World");
+            _logger.Information("Hello, World");
+            _logger.Information("Hello, World");
+
+            Action action = () => InMemorySink.Instance
+                .Should()
+                .NotHaveMessage("Hello, World");
+
+            action
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage("Expected message \"Hello, World\" not to be logged, but it was found 3 times");
+        }
     }
 }

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingMessageExistsThatContainsPattern.cs
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingMessageExistsThatContainsPattern.cs
@@ -53,6 +53,23 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
                 .Appearing().Times(3);
         }
 
+        [Fact]
+        public void GivenThreeMessagesAndAssertingNoMessagesAreLogged_AssertionFails()
+        {
+            _logger.Information("foo");
+            _logger.Information("bar");
+            _logger.Information("baz");
+
+            Action action = () => InMemorySink.Instance
+                .Should()
+                .NotHaveMessage();
+
+            action
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage("Expected no messages to be logged, but found 3 messages");
+        }
+
         private readonly ILogger _logger;
 
         public WhenAssertingMessageExistsThatContainsPattern()

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingMessageExistsThatContainsPattern.cs
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingMessageExistsThatContainsPattern.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
+{
+    public class WhenAssertingMessageExistsThatContainsPattern
+    {
+        [Fact]
+        public void GivenThreeMessagesWithPattern_AssertionSucceeds()
+        {
+            _logger.Information("padding pattern padding");
+            _logger.Information("pattern padding");
+            _logger.Information("padding pattern");
+
+            InMemorySink.Instance
+                .Should()
+                .HaveMessage()
+                .Containing("pattern")
+                .Appearing().Times(3);
+        }
+
+        [Fact]
+        public void GivenThreeMessagesNotMatchingPattern_AssertionFails()
+        {
+            _logger.Information("padding pattern padding");
+            _logger.Information("pattern padding");
+            _logger.Information("padding pattern");
+
+            Action action = () => InMemorySink.Instance
+                .Should()
+                .HaveMessage()
+                .Containing("NOT MATCHING")
+                .Appearing().Times(3);
+
+            action
+                .Should()
+                .Throw<XunitException>()
+                .WithMessage("Expected a message with pattern \"NOT MATCHING\" to be logged");
+        }
+
+        [Fact]
+        public void GivenThreeMessagesAndAssertingAppearanceCount_AssertionSucceeds()
+        {
+            _logger.Information("foo");
+            _logger.Information("bar");
+            _logger.Information("baz");
+
+            InMemorySink.Instance
+                .Should()
+                .HaveMessage()
+                .Appearing().Times(3);
+        }
+
+        private readonly ILogger _logger;
+
+        public WhenAssertingMessageExistsThatContainsPattern()
+        {
+            _logger = new LoggerConfiguration()
+                .WriteTo.InMemory()
+                .CreateLogger();
+        }
+    }
+}

--- a/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds the option to assert that messages with a certain pattern have been logged:

```csharp
InMemorySink.Instance
   .Should()
   .HaveMessage()
   .Containing("some pattern")
   .Appearing().Once();
```

which will match `test some pattern message`.

You can now also verify that any message has been logged:

```csharp
InMemorySink.Instance
   .Should()
   .HaveMessage()
   .Appearing().Times(3);
```

or that no messages have been logged:

```csharp
InMemorySink.Instance
   .Should()
   .NotHaveMessage();
```

or that a specific message has not been logged:

```csharp
InMemorySink.Instance
   .Should()
   .NotHaveMessage("some message");
```
