### PR TITLE
Assertion improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,56 @@ InMemorySink.Instance
                 .NotHaveMessage("a specific message");
 ```
 
+### Asserting properties on messages
+
+When you want to assert that a message has a property you can do that using the `WithProperty` assertion:
+
+```csharp
+InMemorySink.Instance
+    .Should()
+    .HaveMessage("Message with {Property}")
+    .Appearing().Once()
+    .WithProperty("Property");
+```
+
+To then assert that it has a certain value you would use `WithValue`:
+
+```csharp
+InMemorySink.Instance
+    .Should()
+    .HaveMessage("Message with {Property}")
+    .Appearing().Once()
+    .WithProperty("Property")
+    .WithValue("property value");
+```
+
+Asserting that a message has multiple properties can be accomplished using the `And` constraint:
+
+```csharp
+InMemorySink.Instance
+    .Should()
+    .HaveMessage("Message with {Property1} and {Property2}")
+    .Appearing().Once()
+    .WithProperty("Property1")
+    .WithValue("value 1")
+    .And
+    .WithProperty("Property2")
+    .WithValue("value 2");
+```
+
+When you have a log message that appears a number of times and you want to assert that the value of the log property has the expected values you can do that using the `WithValues` assertion:
+
+```csharp
+InMemorySink.Instance
+    .Should()
+    .HaveMessage("Message with {Property1} and {Property2}")
+    .Appearing().Times(3)
+    .WithProperty("Property1")
+    .WithValue("value 1", "value 2", "value 3")
+```
+
+> **Note:** `WithValue` takes an array of values.
+
 ## Clearing log events between tests
 
 Depending on your test framework and test setup you may want to ensure that the log events captured by the `InMemorySink` are cleared so tests

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventAssertion.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventAssertion.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FluentAssertions.Execution;
+﻿using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using Serilog.Events;
 
@@ -15,7 +14,7 @@ namespace Serilog.Sinks.InMemory.Assertions
             Subject = subject;
         }
 
-        protected override string Identifier { get; } = "log event";
+        protected override string Identifier => "log event";
 
         public LogEventPropertyValueAssertions WithProperty(string name, string because = "", params object[] becauseArgs)
         {
@@ -27,6 +26,7 @@ namespace Serilog.Sinks.InMemory.Assertions
                     name);
 
             return new LogEventPropertyValueAssertions(
+                this,
                 Subject.Properties[name],
                 name);
         }

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventPropertyValueAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventPropertyValueAssertions.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions.Execution;
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using Serilog.Events;
 
@@ -6,15 +7,18 @@ namespace Serilog.Sinks.InMemory.Assertions
 {
     public class LogEventPropertyValueAssertions : ReferenceTypeAssertions<LogEventPropertyValue, LogEventPropertyValueAssertions>
     {
-        public LogEventPropertyValueAssertions(LogEventPropertyValue instance, string propertyName)
+        private readonly LogEventAssertion _logEventAssertion;
+
+        public LogEventPropertyValueAssertions(LogEventAssertion logEventAssertion, LogEventPropertyValue instance, string propertyName)
         {
+            _logEventAssertion = logEventAssertion;
             Subject = instance;
             Identifier = propertyName;
         }
 
         protected override string Identifier { get; }
 
-        public void WithValue(object value, string because = "", params object[] becauseArgs)
+        public AndConstraint<LogEventAssertion> WithValue(object value, string because = "", params object[] becauseArgs)
         {
             var actualValue = GetValueFromProperty(Subject);
 
@@ -25,6 +29,8 @@ namespace Serilog.Sinks.InMemory.Assertions
                     Identifier,
                     value,
                     actualValue);
+
+            return new AndConstraint<LogEventAssertion>(_logEventAssertion);
         }
 
         private object GetValueFromProperty(LogEventPropertyValue instance)

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventsAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventsAssertions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
@@ -74,6 +73,18 @@ namespace Serilog.Sinks.InMemory.Assertions
                     level);
 
             return this;
+        }
+
+        public LogEventsPropertyAssertion WithProperty(string propertyName, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.All(logEvent => logEvent.Properties.ContainsKey(propertyName)))
+                .FailWith($"Expected all instances of log message {{0}} to have property {{1}}, but it was not found",
+                    _messageTemplate,
+                    propertyName);
+
+            return new LogEventsPropertyAssertion(this, propertyName);
         }
     }
 }

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventsPropertyAssertion.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventsPropertyAssertion.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using Serilog.Events;
+
+namespace Serilog.Sinks.InMemory.Assertions
+{
+    public class LogEventsPropertyAssertion : ReferenceTypeAssertions<IEnumerable<LogEvent>, LogEventsPropertyAssertion>
+    {
+        private readonly LogEventsAssertions _logEventsAssertions;
+        private readonly IEnumerable<LogEvent> _logEvents;
+
+        public LogEventsPropertyAssertion(LogEventsAssertions logEventsAssertions, string propertyName)
+        {
+            _logEventsAssertions = logEventsAssertions;
+            _logEvents = logEventsAssertions.Subject;
+            Identifier = propertyName;
+        }
+
+        protected override string Identifier { get; }
+
+        public AndConstraint<LogEventsAssertions> WithValues(params object[] values)
+        {
+            Execute.Assertion
+                .ForCondition(_logEvents.Count() == values.Length)
+                .FailWith(
+                    $"Can't assert property values because {values.Length} values were provided while only {_logEvents.Count()} messages were expected");
+
+            var propertyValues = _logEvents
+                .Select(logEvent => GetValueFromProperty(logEvent.Properties[Identifier]))
+                .ToArray();
+
+            var notFound = values
+                .Where(v => !propertyValues.Contains(v))
+                .ToArray();
+
+            Execute.Assertion
+                .ForCondition(!notFound.Any())
+                .FailWith("Expected property values {0} to contain {1} but did not find {2}",
+                    propertyValues,
+                    values,
+                    notFound);
+
+            return new AndConstraint<LogEventsAssertions>(_logEventsAssertions);
+        }
+
+        private object GetValueFromProperty(LogEventPropertyValue instance)
+        {
+            switch(instance)
+            {
+                case ScalarValue scalarValue:
+                    return scalarValue.Value;
+                default:
+                    return Subject.ToString();
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -23,7 +23,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.*" />
-    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.*" />
+    <PackageReference Include="Serilog.Sinks.InMemory" Version="0.*">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Serilog" Version="2.*">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Title>Serilog in-memory sink assertion extensions</Title>
     <Description>FluentAssertions extensions to use with the Serilog.Sinks.InMemory package</Description>
     <Copyright>2020 Sander van Vliet</Copyright>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingAndSInkIsWrittenTo.cs
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingAndSInkIsWrittenTo.cs
@@ -1,0 +1,46 @@
+﻿using Xunit;
+
+namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
+{
+    public class WhenAssertingAndSInkIsWrittenTo
+    {
+        [Fact]
+        public void AssertionShouldNotFailWhenInstanceIsLoggedToAfterInvokingTheAssertion()
+        {
+            /*
+             * This test is meant to verify the behaviour of the assertions
+             * when a message is logged to the instance we're asserting on
+             * after we invoked the assertion.
+             *
+             * The behaviour is that when calling Should(), the assertion
+             * should (pun intended) capture a snapshot of the log events
+             * at the point in time it was invoked.
+             *
+             * This prevents InvalidOperationExceptions because the internal
+             * collection is modified.
+             *
+             * See https://github.com/sandermvanvliet/SerilogSinksInMemory/issues/16
+             */
+            var sink = new InMemorySink();
+
+            var logger = new LoggerConfiguration()
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            // Log 2 messages
+            logger.Information("Message");
+            logger.Information("Message");
+
+            // Start assertion
+            var assertion = sink.Should();
+
+            // Pretend another thread/task/fiber logs another message
+            logger.Information("Message");
+
+            // Continue with the assertion
+            assertion
+                .HaveMessage("Message")
+                .Appearing().Times(2);
+        }
+    }
+}

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingPropertyValuesOnMultipleMessages.cs
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingPropertyValuesOnMultipleMessages.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
+{
+    public class WhenAssertingPropertyValuesOnMultipleMessages
+    {
+        [Fact]
+        public void GivenMessageDoesNotContainProperty_AssertionFails()
+        {
+            _logger.Information("Message without property");
+
+            Action action = () => InMemorySink.Instance
+                .Should()
+                .HaveMessage("Message without property")
+                .Appearing().Times(1)
+                .WithProperty("SomeProperty");
+
+            action
+                .Should()
+                .Throw<Exception>()
+                .Which
+                .Message
+                .Should()
+                .Be("Expected all instances of log message \"Message without property\" to have property \"SomeProperty\", but it was not found");
+        }
+
+        [Fact]
+        public void GivenOneMessageHasNullPropertyValue_AssertionFails()
+        {
+            _logger.Information("Message with {Property}", "val1");
+            _logger.Information("Message with {Property}", null);
+
+            Action action = () => InMemorySink.Instance
+                .Should()
+                .HaveMessage("Message with {Property}")
+                .Appearing().Times(2)
+                .WithProperty("Property")
+                .WithValues("val1", "val1");
+
+            action
+                .Should()
+                .Throw<Exception>()
+                .Which
+                .Message
+                .Should()
+                .Be("Expected all instances of log message \"Message with {Property}\" to have property \"Property\", but it was not found");
+        }
+
+        [Fact]
+        public void GivenMessageAppearsTwiceWithUniquePropertyValues_AssertionForBothValuesPasses()
+        {
+            _logger.Information("Message with {Property}", "val1");
+            _logger.Information("Message with {Property}", "val2");
+
+            InMemorySink.Instance
+                .Should()
+                .HaveMessage("Message with {Property}")
+                .Appearing().Times(2)
+                .WithProperty("Property")
+                .WithValues("val1", "val2");
+        }
+
+        [Fact]
+        public void GivenMessageAppearsTwiceAndAssertingOnThreeValues_AssertionFailsWithNumberOfValuesError()
+        {
+            _logger.Information("Message with {Property}", "val1");
+            _logger.Information("Message with {Property}", "val2");
+
+            Action action = () => InMemorySink.Instance
+                .Should()
+                .HaveMessage("Message with {Property}")
+                .Appearing().Times(2)
+                .WithProperty("Property")
+                .WithValues("val1", "val2", "val3");
+
+            action
+                .Should()
+                .Throw<Exception>()
+                .Which
+                .Message
+                .Should()
+                .Be("Can't assert property values because 3 values were provided while only 2 messages were expected");
+        }
+
+        [Fact]
+        public void GivenMessageAppearsTwiceWithSameValueAndAssertingOnOtherValue_AssertionFails()
+        {
+            _logger.Information("Message with {Property}", "val1");
+            _logger.Information("Message with {Property}", "val1");
+
+            Action action = () => InMemorySink.Instance
+                .Should()
+                .HaveMessage("Message with {Property}")
+                .Appearing().Times(2)
+                .WithProperty("Property")
+                .WithValues("val1", "other");
+
+            action
+                .Should()
+                .Throw<Exception>()
+                .Which
+                .Message
+                .Should()
+                .Be("Expected property values {\"val1\", \"val1\"} to contain {\"val1\", \"other\"} but did not find {\"other\"}");
+        }
+
+        [Fact]
+        public void AssertionShouldFailWithMissingValueEvenIfValuesAreInDifferentOrder()
+        {
+            _logger.Information("Message with {Property}", "val1");
+            _logger.Information("Message with {Property}", "val1");
+
+            Action action = () => InMemorySink.Instance
+                .Should()
+                .HaveMessage("Message with {Property}")
+                .Appearing().Times(2)
+                .WithProperty("Property")
+                .WithValues("other", "val1");
+
+            action
+                .Should()
+                .Throw<Exception>()
+                .Which
+                .Message
+                .Should()
+                .Be("Expected property values {\"val1\", \"val1\"} to contain {\"other\", \"val1\"} but did not find {\"other\"}");
+        }
+
+        [Fact]
+        public void GivenMessageWithTwoPropertiesAndAssertingOnBothProperies_AssertionPasses()
+        {
+            _logger.Information("Message with {Property1} and {Property2}", "val1", "valA");
+            _logger.Information("Message with {Property1} and {Property2}", "val2", "valB");
+
+            InMemorySink.Instance
+                .Should()
+                .HaveMessage("Message with {Property1} and {Property2}")
+                .Appearing().Times(2)
+                .WithProperty("Property1")
+                .WithValues("val1", "val2")
+                .And
+                .WithProperty("Property2")
+                .WithValues("valA", "valB");
+        }
+
+        [Fact]
+        public void GivenMessageWithTwoPropertiesAndAssertingOnBothProperiesWithOneValueNotPresentOnSecondProperty_AssertionFails()
+        {
+            _logger.Information("Message with {Property1} and {Property2}", "val1", "valA");
+            _logger.Information("Message with {Property1} and {Property2}", "val2", "XXX");
+
+            Action action = () => InMemorySink.Instance
+                .Should()
+                .HaveMessage("Message with {Property1} and {Property2}")
+                .Appearing().Times(2)
+                .WithProperty("Property1")
+                .WithValues("val1", "val2")
+                .And
+                .WithProperty("Property2")
+                .WithValues("valA", "valB");
+
+            action
+                .Should()
+                .Throw<Exception>()
+                .Which
+                .Message
+                .Should()
+                .Be("Expected property values {\"valA\", \"XXX\"} to contain {\"valA\", \"valB\"} but did not find {\"valB\"}");
+        }
+
+        private readonly ILogger _logger;
+
+        public WhenAssertingPropertyValuesOnMultipleMessages()
+        {
+            _logger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .WriteTo.InMemory()
+                .CreateLogger();
+        }
+    }
+}

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingScalarLogPropertyExists.cs
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingScalarLogPropertyExists.cs
@@ -124,5 +124,21 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
                 .WithProperty("some_property")
                 .WithValue("some_value");
         }
+
+        [Fact]
+        public void GivenLogMessageWithTwoProperties_BothPropertiesExistOnLogEntry()
+        {
+            _logger.Information("{PropertyOne} {PropertyTwo}", "one", "two");
+
+            InMemorySink.Instance
+                .Should()
+                .HaveMessage()
+                .Appearing().Once()
+                .WithProperty("PropertyOne")
+                .WithValue("one")
+                .And
+                .WithProperty("PropertyTwo")
+                .WithValue("two");
+        }
     }
 }


### PR DESCRIPTION
This PR addresses the feedback from the following issues:

- #15 Property chaining reported by @rafek1241
- #16 InvalidOperationException when asserting reported by @yaroshvitaly
- #17 Check property values for multiple instances of a message reported by @xavierjohn

The version of the assertions package is bumped to 0.7.0