### PR TITLE
Improve assertions for extension friendliness; add DebuggerTypeProxy for InMemorySink; minor docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Serilog.Sinks.InMemory
 
-In-memory sink for Serilog to use for testing with [FluentAssertions](https://fluentassertions.com/) support for easy to write assertions.
+In-memory sink for Serilog to use for testing with [FluentAssertions](https://fluentassertions.com/), [AwesomeAssertions](https://github.com/AwesomeAssertions/AwesomeAssertions) or [Shouldly]() support for easy to write assertions.
 
 ## Build status
 

--- a/src/Serilog.Sinks.InMemory.Assertions.Abstractions/InMemorySinkAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions.Abstractions/InMemorySinkAssertions.cs
@@ -1,7 +1,20 @@
-﻿namespace Serilog.Sinks.InMemory.Assertions
+﻿#nullable enable
+
+using System;
+using Serilog.Events;
+
+namespace Serilog.Sinks.InMemory.Assertions
 {
     public interface InMemorySinkAssertions
     {
+        InMemorySink Subject { get; }
+
+        LogEventsAssertions HaveMessage(
+            Func<LogEvent, bool> predicate,
+            string? predicateErrorName = null,
+            string because = "",
+            params object[] becauseArgs);
+
         LogEventsAssertions HaveMessage(
             string messageTemplate,
             string because = "",
@@ -10,7 +23,13 @@
         PatternLogEventsAssertions HaveMessage();
 
         void NotHaveMessage(
-            string messageTemplate = null,
+            string? messageTemplate = null,
+            string because = "",
+            params object[] becauseArgs);
+
+        void NotHaveMessage(
+            Func<LogEvent, bool> predicate,
+            string? predicateErrorName = null,
             string because = "",
             params object[] becauseArgs);
     }

--- a/src/Serilog.Sinks.InMemory.Assertions.Abstractions/InMemorySinkAssertionsFactory.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions.Abstractions/InMemorySinkAssertionsFactory.cs
@@ -1,0 +1,7 @@
+namespace Serilog.Sinks.InMemory.Assertions
+{
+    public interface InMemorySinkAssertionsFactory
+    {
+        InMemorySinkAssertions CreateInMemorySinkAssertions(InMemorySink snapshotInstance);
+    }
+}

--- a/src/Serilog.Sinks.InMemory.Assertions.Abstractions/LogEventPropertyValueAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions.Abstractions/LogEventPropertyValueAssertions.cs
@@ -1,6 +1,4 @@
-﻿using FluentAssertions;
-
-namespace Serilog.Sinks.InMemory.Assertions;
+﻿namespace Serilog.Sinks.InMemory.Assertions;
 
 public interface LogEventPropertyValueAssertions
 {

--- a/src/Serilog.Sinks.InMemory.Assertions.Abstractions/LogEventsPropertyAssertion.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions.Abstractions/LogEventsPropertyAssertion.cs
@@ -1,6 +1,4 @@
-﻿using FluentAssertions;
-
-namespace Serilog.Sinks.InMemory.Assertions;
+﻿namespace Serilog.Sinks.InMemory.Assertions;
 
 public interface LogEventsPropertyAssertion
 {

--- a/src/Serilog.Sinks.InMemory.Assertions.Abstractions/Serilog.Sinks.InMemory.Assertions.Abstractions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions.Abstractions/Serilog.Sinks.InMemory.Assertions.Abstractions.csproj
@@ -7,12 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.*">
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="Serilog" Version="2.12.0">
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
+      <ProjectReference Include="..\Serilog.Sinks.InMemory\Serilog.Sinks.InMemory.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.InMemory.Assertions/InMemorySinkExtensions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/InMemorySinkExtensions.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
+
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -10,98 +10,97 @@ namespace Serilog.Sinks.InMemory.Assertions
 {
     public static class InMemorySinkAssertionExtensions
     {
-        private static Type? _assertionsType;
-        private static readonly object SyncRoot = new();
+        public static InMemorySinkAssertionsFactory AssertionsFactory { get; }
+
+        static InMemorySinkAssertionExtensions()
+        {
+            var factoryType = GetAssertionsFactoryType() ??
+                              throw new InvalidOperationException("Unable to load InMemorySinkAssertionsFactory");
+
+            AssertionsFactory = (InMemorySinkAssertionsFactory)Activator.CreateInstance(factoryType);
+        }
 
         public static InMemorySinkAssertions Should(this InMemorySink instance)
         {
-            if (_assertionsType == null)
-            {
-                lock (SyncRoot)
-                {
-                    var assemblyLocation =
-                        Path.GetDirectoryName(typeof(InMemorySinkAssertionExtensions).Assembly.Location);
-
-                    if (string.IsNullOrEmpty(assemblyLocation))
-                    {
-                        throw new Exception($"Unable to determine path to load assemblies from");
-                    }
-
-                    string? adapterName = null;
-                    int? majorVersion = null;
-                    Assembly? versionedAssembly = null;
-
-                    // Order is important here, first check the loaded assemblies before
-                    // looking on disk because otherwise we might load FluentAssertions from disk
-                    // while Shouldly is already loaded into the AppDomain and that's the one we
-                    // should be using.
-                    // That's also a guess but hey, if you mix and match assertion frameworks you
-                    // can deal with the fall out.
-                    if (IsFluentAssertionsAlreadyLoadedIntoDomain(out var fluentAssertionsAssembly))
-                    {
-                        adapterName = "FluentAssertions";
-                        majorVersion = fluentAssertionsAssembly.GetName().Version.Major;
-                    }
-                    else if (IsAwesomeAssertionsAlreadyLoadedIntoDomain(out var awesomeAssertionsAssembly))
-                    {
-                        adapterName = "AwesomeAssertions";
-                        majorVersion = awesomeAssertionsAssembly.GetName().Version.Major;
-                    }
-                    else if (IsShouldlyAlreadyLoadedIntoDomain(out var shouldlyAssembly))
-                    {
-                        adapterName = "Shouldly";
-                        majorVersion = shouldlyAssembly.GetName().Version.Major;
-                    }
-                    else if (IsFluentAssertionsAvailableOnDisk(assemblyLocation,
-                                 out var fluentAssertionsOnDiskAssembly))
-                    {
-                        adapterName = "FluentAssertions";
-                        majorVersion = fluentAssertionsOnDiskAssembly.GetName().Version.Major;
-                    }
-                    else if (IsAwesomeAssertionsAvailableOnDisk(assemblyLocation,
-                                 out var awesomeAssertionsOnDiskAssembly))
-                    {
-                        adapterName = "AwesomeAssertions";
-                        majorVersion = awesomeAssertionsOnDiskAssembly.GetName().Version.Major;
-                    }
-                    else if (IsShouldlyAvailableOnDisk(assemblyLocation, out var shouldlyOnDiskAssembly))
-                    {
-                        adapterName = "Shouldly";
-                        majorVersion = shouldlyOnDiskAssembly.GetName().Version.Major;
-                    }
-
-                    if (adapterName != null && majorVersion != null)
-                    {
-                        var versionedLocation = Path.Combine(
-                            assemblyLocation,
-                            $"Serilog.Sinks.InMemory.{adapterName}{majorVersion}.dll");
-
-                        if (!File.Exists(versionedLocation))
-                        {
-                            throw new InvalidOperationException($"Detected {adapterName} version {majorVersion} but the assertions adapter wasn't found on disk");
-                        }
-                        
-                        versionedAssembly = Assembly.LoadFile(versionedLocation);
-                    }
-
-                    if (versionedAssembly != null)
-                    {
-                        _assertionsType = versionedAssembly
-                            .GetTypes()
-                            .SingleOrDefault(t => t.Name == "InMemorySinkAssertionsImpl");
-                    }
-                }
-            }
-
-            if (_assertionsType == null)
-            {
-                throw new InvalidOperationException("Unable to load InMemorySinkAssertions");
-            }
-
             var snapshotInstance = SnapshotOf(instance);
+            return AssertionsFactory.CreateInMemorySinkAssertions(snapshotInstance);
+        }
 
-            return (InMemorySinkAssertions)Activator.CreateInstance(
-                _assertionsType, snapshotInstance);
+        private static Type? GetAssertionsFactoryType()
+        {
+            var assemblyLocation =
+                Path.GetDirectoryName(typeof(InMemorySinkAssertionExtensions).Assembly.Location);
+
+            if (string.IsNullOrEmpty(assemblyLocation))
+            {
+                throw new Exception($"Unable to determine path to load assemblies from");
+            }
+
+            string? adapterName = null;
+            int? majorVersion = null;
+            Assembly? versionedAssembly = null;
+
+            // Order is important here, first check the loaded assemblies before
+            // looking on disk because otherwise we might load FluentAssertions from disk
+            // while Shouldly is already loaded into the AppDomain and that's the one we
+            // should be using.
+            // That's also a guess but hey, if you mix and match assertion frameworks you
+            // can deal with the fall out.
+            if (IsFluentAssertionsAlreadyLoadedIntoDomain(out var fluentAssertionsAssembly))
+            {
+                adapterName = "FluentAssertions";
+                majorVersion = fluentAssertionsAssembly.GetName().Version.Major;
+            }
+            else if (IsAwesomeAssertionsAlreadyLoadedIntoDomain(out var awesomeAssertionsAssembly))
+            {
+                adapterName = "AwesomeAssertions";
+                majorVersion = awesomeAssertionsAssembly.GetName().Version.Major;
+            }
+            else if (IsShouldlyAlreadyLoadedIntoDomain(out var shouldlyAssembly))
+            {
+                adapterName = "Shouldly";
+                majorVersion = shouldlyAssembly.GetName().Version.Major;
+            }
+            else if (IsFluentAssertionsAvailableOnDisk(assemblyLocation,
+                         out var fluentAssertionsOnDiskAssembly))
+            {
+                adapterName = "FluentAssertions";
+                majorVersion = fluentAssertionsOnDiskAssembly.GetName().Version.Major;
+            }
+            else if (IsAwesomeAssertionsAvailableOnDisk(assemblyLocation,
+                         out var awesomeAssertionsOnDiskAssembly))
+            {
+                adapterName = "AwesomeAssertions";
+                majorVersion = awesomeAssertionsOnDiskAssembly.GetName().Version.Major;
+            }
+            else if (IsShouldlyAvailableOnDisk(assemblyLocation, out var shouldlyOnDiskAssembly))
+            {
+                adapterName = "Shouldly";
+                majorVersion = shouldlyOnDiskAssembly.GetName().Version.Major;
+            }
+
+            if (adapterName != null && majorVersion != null)
+            {
+                var versionedLocation = Path.Combine(
+                    assemblyLocation,
+                    $"Serilog.Sinks.InMemory.{adapterName}{majorVersion}.dll");
+
+                if (!File.Exists(versionedLocation))
+                {
+                    throw new InvalidOperationException($"Detected {adapterName} version {majorVersion} but the assertions adapter wasn't found on disk");
+                }
+
+                versionedAssembly = Assembly.LoadFile(versionedLocation);
+            }
+
+            if (versionedAssembly != null)
+            {
+                return versionedAssembly
+                    .GetTypes()
+                    .SingleOrDefault(t => t.Name == "InMemorySinkAssertionsFactoryImpl");
+            }
+
+            return null;
         }
 
         private static bool IsFluentAssertionsAlreadyLoadedIntoDomain(
@@ -161,8 +160,9 @@ namespace Serilog.Sinks.InMemory.Assertions
                 assembly = Assembly.LoadFile(assemblyPath);
 
                 var metadataAttributes = assembly.GetCustomAttributes<AssemblyMetadataAttribute>().ToList();
-                
-                if(!metadataAttributes.Any() || metadataAttributes.Any(metadata => metadata.Value.Contains("FluentAssertions", StringComparison.OrdinalIgnoreCase)))
+
+                if (!metadataAttributes.Any() ||
+                    metadataAttributes.Any(metadata => metadata.Value.Contains("FluentAssertions", StringComparison.OrdinalIgnoreCase)))
                 {
                     return true;
                 }
@@ -176,7 +176,7 @@ namespace Serilog.Sinks.InMemory.Assertions
             string assemblyLocation,
             [NotNullWhen(true)] out Assembly? assembly)
         {
-            var assemblyPath = Path.Combine(assemblyLocation, "FluentAssertions.dll");
+            var assemblyPath = Path.Combine(assemblyLocation, "AwesomeAssertions.dll");
 
             if (File.Exists(assemblyPath))
             {

--- a/src/Serilog.Sinks.InMemory.AwesomeAssertions8/InMemorySinkAssertionsFactoryImpl.cs
+++ b/src/Serilog.Sinks.InMemory.AwesomeAssertions8/InMemorySinkAssertionsFactoryImpl.cs
@@ -1,0 +1,12 @@
+using Serilog.Sinks.InMemory.Assertions;
+
+namespace Serilog.Sinks.InMemory.AwesomeAssertions8
+{
+    public sealed class InMemorySinkAssertionsFactoryImpl : InMemorySinkAssertionsFactory
+    {
+        public InMemorySinkAssertions CreateInMemorySinkAssertions(InMemorySink snapshotInstance)
+        {
+            return new InMemorySinkAssertionsImpl(snapshotInstance);
+        }
+    }
+}

--- a/src/Serilog.Sinks.InMemory.AwesomeAssertions8/InMemorySinkAssertionsImpl.cs
+++ b/src/Serilog.Sinks.InMemory.AwesomeAssertions8/InMemorySinkAssertionsImpl.cs
@@ -1,6 +1,9 @@
-﻿using System.Linq;
+﻿#nullable enable
+using System;
+using System.Linq;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
+using Serilog.Events;
 using Serilog.Sinks.InMemory.Assertions;
 
 namespace Serilog.Sinks.InMemory.AwesomeAssertions8
@@ -10,44 +13,32 @@ namespace Serilog.Sinks.InMemory.AwesomeAssertions8
         public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance) : base(snapshotInstance, AssertionChain.GetOrCreate())
         {
         }
-        
-        /*
-         * Hack attack.
-         *
-         * This is a bit of a dirty way to work around snapshotting the InMemorySink instance
-         * to ensure that you won't get hit by an InvalidOperationException when calling
-         * HaveMessage() and the logger gets called from somewhere else and adds a new
-         * LogEvent to the collection while that method is invoked.
-         *
-         * For now we copy the LogEvents from the current sink and use reflection to assign
-         * it to a new instance of InMemorySink that will be used by the assertions,
-         * effectively creating a snapshot of the InMemorySink that was used by the tests.
-         */
-        private static InMemorySink SnapshotOf(InMemorySink instance)
-        {
-            return instance.Snapshot();
-        }
 
         protected override string Identifier => nameof(InMemorySink);
+
+        public LogEventsAssertions HaveMessage(Func<LogEvent, bool> predicate, string? predicateErrorName = null, string because = "", params object[] becauseArgs)
+        {
+            predicateErrorName ??= "<predicate>";
+            
+            var matches = Subject
+                .LogEvents
+                .Where(predicate)
+                .ToList();
+
+            CurrentAssertionChain
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(matches.Any())
+                .FailWith("Expected message {0} to be logged", predicateErrorName);
+
+            return new LogEventsAssertionsImpl(predicateErrorName, matches, CurrentAssertionChain);
+        }
 
         public LogEventsAssertions HaveMessage(
             string messageTemplate,
             string because = "",
             params object[] becauseArgs)
         {
-            var matches = Subject
-                .LogEvents
-                .Where(logEvent => logEvent.MessageTemplate.Text == messageTemplate)
-                .ToList();
-
-            CurrentAssertionChain
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(matches.Any())
-                .FailWith(
-                    "Expected message {0} to be logged",
-                    messageTemplate);
-
-            return new LogEventsAssertionsImpl(messageTemplate, matches, CurrentAssertionChain);
+            return HaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
         }
 
         public PatternLogEventsAssertions HaveMessage()
@@ -56,20 +47,34 @@ namespace Serilog.Sinks.InMemory.AwesomeAssertions8
         }
 
         public void NotHaveMessage(
-            string messageTemplate = null,
+            string? messageTemplate = null,
             string because = "",
             params object[] becauseArgs)
         {
+            if (messageTemplate != null)
+            {
+                NotHaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
+            }
+            else
+            {
+                NotHaveMessage(null, messageTemplate, because, becauseArgs);
+            }
+        }
+
+        public void NotHaveMessage(Func<LogEvent, bool>? predicate, string? predicateErrorName = null, string because = "", params object[] becauseArgs)
+        {
+            predicateErrorName ??= "<predicate>";
+            
             int count;
             string failureMessage;
 
-            if (messageTemplate != null)
+            if (predicate != null)
             {
                 count = Subject
-                .LogEvents
-                .Count(logEvent => logEvent.MessageTemplate.Text == messageTemplate);
+                    .LogEvents
+                    .Count(predicate);
                 
-                failureMessage = $"Expected message \"{messageTemplate}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
+                failureMessage = $"Expected message \"{predicateErrorName}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
             }
             else
             {

--- a/src/Serilog.Sinks.InMemory.AwesomeAssertions9/InMemorySinkAssertionsFactoryImpl.cs
+++ b/src/Serilog.Sinks.InMemory.AwesomeAssertions9/InMemorySinkAssertionsFactoryImpl.cs
@@ -1,0 +1,12 @@
+using Serilog.Sinks.InMemory.Assertions;
+
+namespace Serilog.Sinks.InMemory.AwesomeAssertions9
+{
+    public sealed class InMemorySinkAssertionsFactoryImpl : InMemorySinkAssertionsFactory
+    {
+        public InMemorySinkAssertions CreateInMemorySinkAssertions(InMemorySink snapshotInstance)
+        {
+            return new InMemorySinkAssertionsImpl(snapshotInstance);
+        }
+    }
+}

--- a/src/Serilog.Sinks.InMemory.AwesomeAssertions9/InMemorySinkAssertionsImpl.cs
+++ b/src/Serilog.Sinks.InMemory.AwesomeAssertions9/InMemorySinkAssertionsImpl.cs
@@ -1,53 +1,50 @@
-﻿using System.Linq;
+﻿#nullable enable
+
+using System;
+using System.Linq;
 using AwesomeAssertions.Execution;
 using AwesomeAssertions.Primitives;
+using Serilog.Events;
 using Serilog.Sinks.InMemory.Assertions;
 
 namespace Serilog.Sinks.InMemory.AwesomeAssertions9
 {
     public class InMemorySinkAssertionsImpl : ReferenceTypeAssertions<InMemorySink, InMemorySinkAssertionsImpl>, InMemorySinkAssertions
     {
-        public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance) : base(snapshotInstance, AssertionChain.GetOrCreate())
+        public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance)
+            : base(snapshotInstance, AssertionChain.GetOrCreate())
         {
-        }
-        
-        /*
-         * Hack attack.
-         *
-         * This is a bit of a dirty way to work around snapshotting the InMemorySink instance
-         * to ensure that you won't get hit by an InvalidOperationException when calling
-         * HaveMessage() and the logger gets called from somewhere else and adds a new
-         * LogEvent to the collection while that method is invoked.
-         *
-         * For now we copy the LogEvents from the current sink and use reflection to assign
-         * it to a new instance of InMemorySink that will be used by the assertions,
-         * effectively creating a snapshot of the InMemorySink that was used by the tests.
-         */
-        private static InMemorySink SnapshotOf(InMemorySink instance)
-        {
-            return instance.Snapshot();
         }
 
         protected override string Identifier => nameof(InMemorySink);
+
+        public LogEventsAssertions HaveMessage(
+            Func<LogEvent, bool> predicate,
+            string? predicateErrorName = null,
+            string because = "",
+            params object[] becauseArgs)
+        {
+            predicateErrorName ??= "<predicate>";
+
+            var matches = Subject
+                .LogEvents
+                .Where(predicate)
+                .ToList();
+
+            CurrentAssertionChain
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(matches.Any())
+                .FailWith("Expected message {0} to be logged", predicateErrorName);
+
+            return new LogEventsAssertionsImpl(predicateErrorName, matches, CurrentAssertionChain);
+        }
 
         public LogEventsAssertions HaveMessage(
             string messageTemplate,
             string because = "",
             params object[] becauseArgs)
         {
-            var matches = Subject
-                .LogEvents
-                .Where(logEvent => logEvent.MessageTemplate.Text == messageTemplate)
-                .ToList();
-
-            CurrentAssertionChain
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(matches.Any())
-                .FailWith(
-                    "Expected message {0} to be logged",
-                    messageTemplate);
-
-            return new LogEventsAssertionsImpl(messageTemplate, matches, CurrentAssertionChain);
+            return HaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
         }
 
         public PatternLogEventsAssertions HaveMessage()
@@ -56,20 +53,34 @@ namespace Serilog.Sinks.InMemory.AwesomeAssertions9
         }
 
         public void NotHaveMessage(
-            string messageTemplate = null,
+            string? messageTemplate = null,
             string because = "",
             params object[] becauseArgs)
         {
+            if (messageTemplate != null)
+            {
+                NotHaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
+            }
+            else
+            {
+                NotHaveMessage(null, messageTemplate, because, becauseArgs);
+            }
+        }
+
+        public void NotHaveMessage(Func<LogEvent, bool>? predicate, string? predicateErrorName = null, string because = "", params object[] becauseArgs)
+        {
+            predicateErrorName ??= "<predicate>";
+
             int count;
             string failureMessage;
 
-            if (messageTemplate != null)
+            if (predicate != null)
             {
                 count = Subject
-                .LogEvents
-                .Count(logEvent => logEvent.MessageTemplate.Text == messageTemplate);
-                
-                failureMessage = $"Expected message \"{messageTemplate}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
+                    .LogEvents
+                    .Count(predicate);
+
+                failureMessage = $"Expected message \"{predicateErrorName}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
             }
             else
             {

--- a/src/Serilog.Sinks.InMemory.FluentAssertions5/InMemorySinkAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.FluentAssertions5/InMemorySinkAssertions.cs
@@ -1,43 +1,34 @@
-﻿using System.Linq;
+﻿#nullable enable
+
+using System;
+using System.Linq;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
+using Serilog.Events;
 using Serilog.Sinks.InMemory.Assertions;
 
 namespace Serilog.Sinks.InMemory.FluentAssertions5
 {
     public class InMemorySinkAssertionsImpl : ReferenceTypeAssertions<InMemorySink, InMemorySinkAssertionsImpl>, InMemorySinkAssertions
     {
-        public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance) : base(snapshotInstance)
+        public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance)
+            : base(snapshotInstance)
         {
-        }
-        
-        /*
-         * Hack attack.
-         *
-         * This is a bit of a dirty way to work around snapshotting the InMemorySink instance
-         * to ensure that you won't get hit by an InvalidOperationException when calling
-         * HaveMessage() and the logger gets called from somewhere else and adds a new
-         * LogEvent to the collection while that method is invoked.
-         *
-         * For now we copy the LogEvents from the current sink and use reflection to assign
-         * it to a new instance of InMemorySink that will be used by the assertions,
-         * effectively creating a snapshot of the InMemorySink that was used by the tests.
-         */
-        private static InMemorySink SnapshotOf(InMemorySink instance)
-        {
-            return instance.Snapshot();
         }
 
         protected override string Identifier => nameof(InMemorySink);
 
         public LogEventsAssertions HaveMessage(
-            string messageTemplate,
+            Func<LogEvent, bool> predicate,
+            string? predicateErrorName = null,
             string because = "",
             params object[] becauseArgs)
         {
+            predicateErrorName ??= "<predicate>";
+
             var matches = Subject
                 .LogEvents
-                .Where(logEvent => logEvent.MessageTemplate.Text == messageTemplate)
+                .Where(predicate)
                 .ToList();
 
             Execute.Assertion
@@ -45,9 +36,17 @@ namespace Serilog.Sinks.InMemory.FluentAssertions5
                 .ForCondition(matches.Any())
                 .FailWith(
                     "Expected message {0} to be logged",
-                    messageTemplate);
+                    predicateErrorName);
 
-            return new LogEventsAssertionsImpl(messageTemplate, matches);
+            return new LogEventsAssertionsImpl(predicateErrorName, matches);
+        }
+
+        public LogEventsAssertions HaveMessage(
+            string messageTemplate,
+            string because = "",
+            params object[] becauseArgs)
+        {
+            return HaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
         }
 
         public PatternLogEventsAssertions HaveMessage()
@@ -56,20 +55,34 @@ namespace Serilog.Sinks.InMemory.FluentAssertions5
         }
 
         public void NotHaveMessage(
-            string messageTemplate = null,
+            string? messageTemplate = null,
             string because = "",
             params object[] becauseArgs)
         {
+            if (messageTemplate != null)
+            {
+                NotHaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
+            }
+            else
+            {
+                NotHaveMessage(null, messageTemplate, because, becauseArgs);
+            }
+        }
+
+        public void NotHaveMessage(Func<LogEvent, bool>? predicate, string? predicateErrorName = null, string because = "", params object[] becauseArgs)
+        {
+            predicateErrorName ??= "<predicate>";
+
             int count;
             string failureMessage;
 
-            if (messageTemplate != null)
+            if (predicate != null)
             {
                 count = Subject
-                .LogEvents
-                .Count(logEvent => logEvent.MessageTemplate.Text == messageTemplate);
-                
-                failureMessage = $"Expected message \"{messageTemplate}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
+                    .LogEvents
+                    .Count(predicate);
+
+                failureMessage = $"Expected message \"{predicateErrorName}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
             }
             else
             {

--- a/src/Serilog.Sinks.InMemory.FluentAssertions5/InMemorySinkAssertionsFactoryImpl.cs
+++ b/src/Serilog.Sinks.InMemory.FluentAssertions5/InMemorySinkAssertionsFactoryImpl.cs
@@ -1,0 +1,12 @@
+using Serilog.Sinks.InMemory.Assertions;
+
+namespace Serilog.Sinks.InMemory.FluentAssertions5
+{
+    public sealed class InMemorySinkAssertionsFactoryImpl : InMemorySinkAssertionsFactory
+    {
+        public InMemorySinkAssertions CreateInMemorySinkAssertions(InMemorySink snapshotInstance)
+        {
+            return new InMemorySinkAssertionsImpl(snapshotInstance);
+        }
+    }
+}

--- a/src/Serilog.Sinks.InMemory.FluentAssertions6/InMemorySinkAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.FluentAssertions6/InMemorySinkAssertions.cs
@@ -1,43 +1,34 @@
-﻿using System.Linq;
+﻿#nullable enable
+
+using System;
+using System.Linq;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
+using Serilog.Events;
 using Serilog.Sinks.InMemory.Assertions;
 
 namespace Serilog.Sinks.InMemory.FluentAssertions6
 {
     public class InMemorySinkAssertionsImpl : ReferenceTypeAssertions<InMemorySink, InMemorySinkAssertionsImpl>, InMemorySinkAssertions
     {
-        public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance) : base(snapshotInstance)
+        public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance)
+            : base(snapshotInstance)
         {
-        }
-        
-        /*
-         * Hack attack.
-         *
-         * This is a bit of a dirty way to work around snapshotting the InMemorySink instance
-         * to ensure that you won't get hit by an InvalidOperationException when calling
-         * HaveMessage() and the logger gets called from somewhere else and adds a new
-         * LogEvent to the collection while that method is invoked.
-         *
-         * For now we copy the LogEvents from the current sink and use reflection to assign
-         * it to a new instance of InMemorySink that will be used by the assertions,
-         * effectively creating a snapshot of the InMemorySink that was used by the tests.
-         */
-        private static InMemorySink SnapshotOf(InMemorySink instance)
-        {
-            return instance.Snapshot();
         }
 
         protected override string Identifier => nameof(InMemorySink);
 
         public LogEventsAssertions HaveMessage(
-            string messageTemplate,
+            Func<LogEvent, bool> predicate,
+            string? predicateErrorName = null,
             string because = "",
             params object[] becauseArgs)
         {
+            predicateErrorName ??= "<predicate>";
+
             var matches = Subject
                 .LogEvents
-                .Where(logEvent => logEvent.MessageTemplate.Text == messageTemplate)
+                .Where(predicate)
                 .ToList();
 
             Execute.Assertion
@@ -45,9 +36,17 @@ namespace Serilog.Sinks.InMemory.FluentAssertions6
                 .ForCondition(matches.Any())
                 .FailWith(
                     "Expected message {0} to be logged",
-                    messageTemplate);
+                    predicateErrorName);
 
-            return new LogEventsAssertionsImpl(messageTemplate, matches);
+            return new LogEventsAssertionsImpl(predicateErrorName, matches);
+        }
+
+        public LogEventsAssertions HaveMessage(
+            string messageTemplate,
+            string because = "",
+            params object[] becauseArgs)
+        {
+            return HaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
         }
 
         public PatternLogEventsAssertions HaveMessage()
@@ -56,20 +55,34 @@ namespace Serilog.Sinks.InMemory.FluentAssertions6
         }
 
         public void NotHaveMessage(
-            string messageTemplate = null,
+            string? messageTemplate = null,
             string because = "",
             params object[] becauseArgs)
         {
+            if (messageTemplate != null)
+            {
+                NotHaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
+            }
+            else
+            {
+                NotHaveMessage(null, messageTemplate, because, becauseArgs);
+            }
+        }
+
+        public void NotHaveMessage(Func<LogEvent, bool>? predicate, string? predicateErrorName = null, string because = "", params object[] becauseArgs)
+        {
+            predicateErrorName ??= "<predicate>";
+
             int count;
             string failureMessage;
 
-            if (messageTemplate != null)
+            if (predicate != null)
             {
                 count = Subject
-                .LogEvents
-                .Count(logEvent => logEvent.MessageTemplate.Text == messageTemplate);
-                
-                failureMessage = $"Expected message \"{messageTemplate}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
+                    .LogEvents
+                    .Count(predicate);
+
+                failureMessage = $"Expected message \"{predicateErrorName}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
             }
             else
             {

--- a/src/Serilog.Sinks.InMemory.FluentAssertions6/InMemorySinkAssertionsFactoryImpl.cs
+++ b/src/Serilog.Sinks.InMemory.FluentAssertions6/InMemorySinkAssertionsFactoryImpl.cs
@@ -1,0 +1,12 @@
+using Serilog.Sinks.InMemory.Assertions;
+
+namespace Serilog.Sinks.InMemory.FluentAssertions6
+{
+    public sealed class InMemorySinkAssertionsFactoryImpl : InMemorySinkAssertionsFactory
+    {
+        public InMemorySinkAssertions CreateInMemorySinkAssertions(InMemorySink snapshotInstance)
+        {
+            return new InMemorySinkAssertionsImpl(snapshotInstance);
+        }
+    }
+}

--- a/src/Serilog.Sinks.InMemory.FluentAssertions7/InMemorySinkAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.FluentAssertions7/InMemorySinkAssertions.cs
@@ -1,43 +1,34 @@
-﻿using System.Linq;
+﻿#nullable enable
+
+using System;
+using System.Linq;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
+using Serilog.Events;
 using Serilog.Sinks.InMemory.Assertions;
 
 namespace Serilog.Sinks.InMemory.FluentAssertions7
 {
     public class InMemorySinkAssertionsImpl : ReferenceTypeAssertions<InMemorySink, InMemorySinkAssertionsImpl>, InMemorySinkAssertions
     {
-        public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance) : base(snapshotInstance)
+        public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance)
+            : base(snapshotInstance)
         {
-        }
-        
-        /*
-         * Hack attack.
-         *
-         * This is a bit of a dirty way to work around snapshotting the InMemorySink instance
-         * to ensure that you won't get hit by an InvalidOperationException when calling
-         * HaveMessage() and the logger gets called from somewhere else and adds a new
-         * LogEvent to the collection while that method is invoked.
-         *
-         * For now we copy the LogEvents from the current sink and use reflection to assign
-         * it to a new instance of InMemorySink that will be used by the assertions,
-         * effectively creating a snapshot of the InMemorySink that was used by the tests.
-         */
-        private static InMemorySink SnapshotOf(InMemorySink instance)
-        {
-            return instance.Snapshot();
         }
 
         protected override string Identifier => nameof(InMemorySink);
 
         public LogEventsAssertions HaveMessage(
-            string messageTemplate,
+            Func<LogEvent, bool> predicate,
+            string? predicateErrorName = null,
             string because = "",
             params object[] becauseArgs)
         {
+            predicateErrorName ??= "<predicate>";
+
             var matches = Subject
                 .LogEvents
-                .Where(logEvent => logEvent.MessageTemplate.Text == messageTemplate)
+                .Where(predicate)
                 .ToList();
 
             Execute.Assertion
@@ -45,9 +36,17 @@ namespace Serilog.Sinks.InMemory.FluentAssertions7
                 .ForCondition(matches.Any())
                 .FailWith(
                     "Expected message {0} to be logged",
-                    messageTemplate);
+                    predicateErrorName);
 
-            return new LogEventsAssertionsImpl(messageTemplate, matches);
+            return new LogEventsAssertionsImpl(predicateErrorName, matches);
+        }
+
+        public LogEventsAssertions HaveMessage(
+            string messageTemplate,
+            string because = "",
+            params object[] becauseArgs)
+        {
+            return HaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
         }
 
         public PatternLogEventsAssertions HaveMessage()
@@ -56,20 +55,34 @@ namespace Serilog.Sinks.InMemory.FluentAssertions7
         }
 
         public void NotHaveMessage(
-            string messageTemplate = null,
+            string? messageTemplate = null,
             string because = "",
             params object[] becauseArgs)
         {
+            if (messageTemplate != null)
+            {
+                NotHaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
+            }
+            else
+            {
+                NotHaveMessage(null, messageTemplate, because, becauseArgs);
+            }
+        }
+
+        public void NotHaveMessage(Func<LogEvent, bool>? predicate, string? predicateErrorName = null, string because = "", params object[] becauseArgs)
+        {
+            predicateErrorName ??= "<predicate>";
+
             int count;
             string failureMessage;
 
-            if (messageTemplate != null)
+            if (predicate != null)
             {
                 count = Subject
-                .LogEvents
-                .Count(logEvent => logEvent.MessageTemplate.Text == messageTemplate);
-                
-                failureMessage = $"Expected message \"{messageTemplate}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
+                    .LogEvents
+                    .Count(predicate);
+
+                failureMessage = $"Expected message \"{predicateErrorName}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
             }
             else
             {

--- a/src/Serilog.Sinks.InMemory.FluentAssertions7/InMemorySinkAssertionsFactoryImpl.cs
+++ b/src/Serilog.Sinks.InMemory.FluentAssertions7/InMemorySinkAssertionsFactoryImpl.cs
@@ -1,0 +1,12 @@
+using Serilog.Sinks.InMemory.Assertions;
+
+namespace Serilog.Sinks.InMemory.FluentAssertions7
+{
+    public sealed class InMemorySinkAssertionsFactoryImpl : InMemorySinkAssertionsFactory
+    {
+        public InMemorySinkAssertions CreateInMemorySinkAssertions(InMemorySink snapshotInstance)
+        {
+            return new InMemorySinkAssertionsImpl(snapshotInstance);
+        }
+    }
+}

--- a/src/Serilog.Sinks.InMemory.FluentAssertions8/InMemorySinkAssertionsFactoryImpl.cs
+++ b/src/Serilog.Sinks.InMemory.FluentAssertions8/InMemorySinkAssertionsFactoryImpl.cs
@@ -1,0 +1,12 @@
+using Serilog.Sinks.InMemory.Assertions;
+
+namespace Serilog.Sinks.InMemory.FluentAssertions8
+{
+    public sealed class InMemorySinkAssertionsFactoryImpl : InMemorySinkAssertionsFactory
+    {
+        public InMemorySinkAssertions CreateInMemorySinkAssertions(InMemorySink snapshotInstance)
+        {
+            return new InMemorySinkAssertionsImpl(snapshotInstance);
+        }
+    }
+}

--- a/src/Serilog.Sinks.InMemory.FluentAssertions8/InMemorySinkAssertionsImpl.cs
+++ b/src/Serilog.Sinks.InMemory.FluentAssertions8/InMemorySinkAssertionsImpl.cs
@@ -1,53 +1,52 @@
-﻿using System.Linq;
+﻿#nullable enable
+
+using System;
+using System.Linq;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
+using Serilog.Events;
 using Serilog.Sinks.InMemory.Assertions;
 
 namespace Serilog.Sinks.InMemory.FluentAssertions8
 {
     public class InMemorySinkAssertionsImpl : ReferenceTypeAssertions<InMemorySink, InMemorySinkAssertionsImpl>, InMemorySinkAssertions
     {
-        public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance) : base(snapshotInstance, AssertionChain.GetOrCreate())
+        public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance)
+            : base(snapshotInstance, AssertionChain.GetOrCreate())
         {
-        }
-        
-        /*
-         * Hack attack.
-         *
-         * This is a bit of a dirty way to work around snapshotting the InMemorySink instance
-         * to ensure that you won't get hit by an InvalidOperationException when calling
-         * HaveMessage() and the logger gets called from somewhere else and adds a new
-         * LogEvent to the collection while that method is invoked.
-         *
-         * For now we copy the LogEvents from the current sink and use reflection to assign
-         * it to a new instance of InMemorySink that will be used by the assertions,
-         * effectively creating a snapshot of the InMemorySink that was used by the tests.
-         */
-        private static InMemorySink SnapshotOf(InMemorySink instance)
-        {
-            return instance.Snapshot();
         }
 
         protected override string Identifier => nameof(InMemorySink);
 
         public LogEventsAssertions HaveMessage(
-            string messageTemplate,
+            Func<LogEvent, bool> predicate,
+            string? predicateErrorName = null,
             string because = "",
             params object[] becauseArgs)
         {
+            predicateErrorName ??= "<predicate>";
+
             var matches = Subject
                 .LogEvents
-                .Where(logEvent => logEvent.MessageTemplate.Text == messageTemplate)
-                .ToList();
+                .Where(predicate)
+                .ToArray();
 
             CurrentAssertionChain
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(matches.Any())
                 .FailWith(
                     "Expected message {0} to be logged",
-                    messageTemplate);
+                    predicateErrorName);
 
-            return new LogEventsAssertionsImpl(messageTemplate, matches, CurrentAssertionChain);
+            return new LogEventsAssertionsImpl(predicateErrorName, matches, CurrentAssertionChain);
+        }
+
+        public LogEventsAssertions HaveMessage(
+            string messageTemplate,
+            string because = "",
+            params object[] becauseArgs)
+        {
+            return HaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
         }
 
         public PatternLogEventsAssertions HaveMessage()
@@ -56,20 +55,34 @@ namespace Serilog.Sinks.InMemory.FluentAssertions8
         }
 
         public void NotHaveMessage(
-            string messageTemplate = null,
+            string? messageTemplate = null,
             string because = "",
             params object[] becauseArgs)
         {
+            if (messageTemplate != null)
+            {
+                NotHaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
+            }
+            else
+            {
+                NotHaveMessage(null, messageTemplate, because, becauseArgs);
+            }
+        }
+
+        public void NotHaveMessage(Func<LogEvent, bool>? predicate, string? predicateErrorName = null, string because = "", params object[] becauseArgs)
+        {
+            predicateErrorName ??= "<predicate>";
+
             int count;
             string failureMessage;
 
-            if (messageTemplate != null)
+            if (predicate != null)
             {
                 count = Subject
-                .LogEvents
-                .Count(logEvent => logEvent.MessageTemplate.Text == messageTemplate);
-                
-                failureMessage = $"Expected message \"{messageTemplate}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
+                    .LogEvents
+                    .Count(predicate);
+
+                failureMessage = $"Expected message \"{predicateErrorName}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
             }
             else
             {

--- a/src/Serilog.Sinks.InMemory.Shouldly4/InMemorySinkAssertionsFactoryImpl.cs
+++ b/src/Serilog.Sinks.InMemory.Shouldly4/InMemorySinkAssertionsFactoryImpl.cs
@@ -1,0 +1,12 @@
+using Serilog.Sinks.InMemory.Assertions;
+
+namespace Serilog.Sinks.InMemory.Shouldly4
+{
+    public sealed class InMemorySinkAssertionsFactoryImpl : InMemorySinkAssertionsFactory
+    {
+        public InMemorySinkAssertions CreateInMemorySinkAssertions(InMemorySink snapshotInstance)
+        {
+            return new InMemorySinkAssertionsImpl(snapshotInstance);
+        }
+    }
+}

--- a/src/Serilog.Sinks.InMemory.Shouldly4/InMemorySinkAssertionsImpl.cs
+++ b/src/Serilog.Sinks.InMemory.Shouldly4/InMemorySinkAssertionsImpl.cs
@@ -1,34 +1,42 @@
-﻿using System.Linq;
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using Serilog.Events;
 using Serilog.Sinks.InMemory.Assertions;
 using Shouldly;
 
 namespace Serilog.Sinks.InMemory.Shouldly4
 {
-    [ShouldlyMethods] 
+    [ShouldlyMethods]
     public class InMemorySinkAssertionsImpl : InMemorySinkAssertions
     {
-        private readonly InMemorySink _snapshotInstance;
-
         public InMemorySinkAssertionsImpl(InMemorySink snapshotInstance)
         {
-            _snapshotInstance = snapshotInstance;
+            Subject = snapshotInstance;
         }
-        
-        /*
-         * Hack attack.
-         *
-         * This is a bit of a dirty way to work around snapshotting the InMemorySink instance
-         * to ensure that you won't get hit by an InvalidOperationException when calling
-         * HaveMessage() and the logger gets called from somewhere else and adds a new
-         * LogEvent to the collection while that method is invoked.
-         *
-         * For now we copy the LogEvents from the current sink and use reflection to assign
-         * it to a new instance of InMemorySink that will be used by the assertions,
-         * effectively creating a snapshot of the InMemorySink that was used by the tests.
-         */
-        private static InMemorySink SnapshotOf(InMemorySink instance)
+
+        public InMemorySink Subject { get; }
+
+        public LogEventsAssertions HaveMessage(
+            Func<LogEvent, bool> predicate,
+            string? predicateErrorName = null,
+            string because = "",
+            params object[] becauseArgs)
         {
-            return instance.Snapshot();
+            predicateErrorName ??= "<predicate>";
+
+            var matches = Subject
+                .LogEvents
+                .Where(predicate)
+                .ToArray();
+
+            if (!matches.Any())
+            {
+                throw new ShouldAssertException($"Expected message \"{predicateErrorName}\" to be logged");
+            }
+
+            return new LogEventsAssertionsImpl(predicateErrorName, matches);
         }
 
         public LogEventsAssertions HaveMessage(
@@ -36,43 +44,47 @@ namespace Serilog.Sinks.InMemory.Shouldly4
             string because = "",
             params object[] becauseArgs)
         {
-            var matches = _snapshotInstance
-                .LogEvents
-                .Where(logEvent => logEvent.MessageTemplate.Text == messageTemplate)
-                .ToList();
-
-            if (!matches.Any())
-            {
-                throw new ShouldAssertException($"Expected message \"{messageTemplate}\" to be logged");
-            }
-
-            return new LogEventsAssertionsImpl(messageTemplate, matches);
+            return HaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
         }
 
         public PatternLogEventsAssertions HaveMessage()
         {
-            return new PatternLogEventsAssertionsImpl(_snapshotInstance.LogEvents);
+            return new PatternLogEventsAssertionsImpl(Subject.LogEvents);
         }
 
         public void NotHaveMessage(
-            string messageTemplate = null,
+            string? messageTemplate = null,
             string because = "",
             params object[] becauseArgs)
         {
-            int count;
-            string failureMessage;
-
             if (messageTemplate != null)
             {
-                count = _snapshotInstance
-                .LogEvents
-                .Count(logEvent => logEvent.MessageTemplate.Text == messageTemplate);
-                
-                failureMessage = $"Expected message \"{messageTemplate}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
+                NotHaveMessage(logEvent => logEvent.MessageTemplate.Text == messageTemplate, messageTemplate, because, becauseArgs);
             }
             else
             {
-                count = _snapshotInstance
+                NotHaveMessage(null, messageTemplate, because, becauseArgs);
+            }
+        }
+
+        public void NotHaveMessage(Func<LogEvent, bool>? predicate, string? predicateErrorName = null, string because = "", params object[] becauseArgs)
+        {
+            predicateErrorName ??= "<predicate>";
+
+            int count;
+            string failureMessage;
+
+            if (predicate != null)
+            {
+                count = Subject
+                    .LogEvents
+                    .Count(predicate);
+
+                failureMessage = $"Expected message \"{predicateErrorName}\" not to be logged, but it was found {(count > 1 ? $"{count} times" : "once")}";
+            }
+            else
+            {
+                count = Subject
                     .LogEvents
                     .Count();
 

--- a/src/Serilog.Sinks.InMemory/InMemorySink.cs
+++ b/src/Serilog.Sinks.InMemory/InMemorySink.cs
@@ -1,5 +1,9 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Serilog.Core;
@@ -7,14 +11,17 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.InMemory
 {
+    [DebuggerTypeProxy(typeof(InMemorySinkAdvDebugProxy))]
     public class InMemorySink : ILogEventSink, IDisposable
     {
         private static readonly AsyncLocal<InMemorySink> LocalInstance = new AsyncLocal<InMemorySink>();
 
+        private ReadOnlyCollection<LogEvent>? _logEventsSnapshot;
         private readonly List<LogEvent> _logEvents;
         private readonly object _snapShotLock = new object();
 
-        public InMemorySink() : this(new List<LogEvent>())
+        public InMemorySink()
+            : this(new List<LogEvent>())
         {
         }
 
@@ -27,16 +34,12 @@ namespace Serilog.Sinks.InMemory
         {
             get
             {
-                if (LocalInstance.Value == null)
-                {
-                    LocalInstance.Value = new InMemorySink();
-                }
-
+                LocalInstance.Value ??= new InMemorySink();
                 return LocalInstance.Value;
             }
         }
 
-        public IEnumerable<LogEvent> LogEvents => _logEvents.AsReadOnly();
+        public IEnumerable<LogEvent> LogEvents => GetLogEvents();
 
         public void Dispose()
         {
@@ -48,17 +51,33 @@ namespace Serilog.Sinks.InMemory
             lock (_snapShotLock)
             {
                 _logEvents.Add(logEvent);
+                _logEventsSnapshot = null;
             }
+        }
+
+        private IEnumerable<LogEvent> GetLogEvents()
+        {
+            if (_logEventsSnapshot == null)
+            {
+                lock (_snapShotLock)
+                {
+                    _logEventsSnapshot ??= _logEvents.AsReadOnly();
+                }
+            }
+
+            return _logEventsSnapshot;
         }
 
         public InMemorySink Snapshot()
         {
-            lock (_snapShotLock)
-            {
-                var currentLogEvents = _logEvents.AsReadOnly().ToList();
+            var currentLogEvents = GetLogEvents().ToList();
+            return new InMemorySinkSnapshot(currentLogEvents);
+        }
 
-                return new InMemorySinkSnapshot(currentLogEvents);
-            }
+        public InMemorySink Snapshot(Func<LogEvent, bool> predicate)
+        {
+            var currentLogEvents = GetLogEvents().Where(predicate).ToList();
+            return new InMemorySinkSnapshot(currentLogEvents);
         }
     }
 }

--- a/src/Serilog.Sinks.InMemory/InMemorySinkAdvDebugProxy.cs
+++ b/src/Serilog.Sinks.InMemory/InMemorySinkAdvDebugProxy.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Events;
+
+namespace Serilog.Sinks.InMemory
+{
+    internal sealed class InMemorySinkAdvDebugProxy(InMemorySink sink)
+        : List<DebugLogEvent>(sink.LogEvents.Select(logEvent => new DebugLogEvent(logEvent)));
+
+    internal sealed class DebugLogEvent(LogEvent logEvent)
+    {
+        public LogEventLevel Level => logEvent.Level;
+        public string Message => logEvent.RenderMessage();
+
+        public string MessageTemplate => logEvent.MessageTemplate.ToString();
+
+        public IReadOnlyDictionary<string, LogEventPropertyValue> Properties => logEvent.Properties;
+
+        public Exception? Exception => logEvent.Exception;
+
+        public LogEvent OriginalLogEvent => logEvent;
+
+        public override string ToString() => Message;
+    }
+}

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.AwesomeAssertions8/Serilog.Sinks.InMemory.Assertions.Tests.Unit.AwesomeAssertions8.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.AwesomeAssertions8/Serilog.Sinks.InMemory.Assertions.Tests.Unit.AwesomeAssertions8.csproj
@@ -26,29 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\Repro.cs">
-      <Link>Repro.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingAndSInkIsWrittenTo.cs">
-      <Link>WhenAssertingAndSInkIsWrittenTo.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventHasLevel.cs">
-      <Link>WhenAssertingLogEventHasLevel.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventsExist.cs">
-      <Link>WhenAssertingLogEventsExist.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingMessageExistsThatContainsPattern.cs">
-      <Link>WhenAssertingMessageExistsThatContainsPattern.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingPropertyValuesOnMultipleMessages.cs">
-      <Link>WhenAssertingPropertyValuesOnMultipleMessages.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingScalarLogPropertyExists.cs">
-      <Link>WhenAssertingScalarLogPropertyExists.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingStructuredLogPropertyExists.cs">
-      <Link>WhenAssertingStructuredLogPropertyExists.cs</Link>
-    </Compile>
+    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\**\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>    
   </ItemGroup>
 </Project>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.AwesomeAssertions9/Serilog.Sinks.InMemory.Assertions.Tests.Unit.AwesomeAssertions9.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.AwesomeAssertions9/Serilog.Sinks.InMemory.Assertions.Tests.Unit.AwesomeAssertions9.csproj
@@ -26,29 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\Repro.cs">
-      <Link>Repro.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingAndSInkIsWrittenTo.cs">
-      <Link>WhenAssertingAndSInkIsWrittenTo.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventHasLevel.cs">
-      <Link>WhenAssertingLogEventHasLevel.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventsExist.cs">
-      <Link>WhenAssertingLogEventsExist.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingMessageExistsThatContainsPattern.cs">
-      <Link>WhenAssertingMessageExistsThatContainsPattern.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingPropertyValuesOnMultipleMessages.cs">
-      <Link>WhenAssertingPropertyValuesOnMultipleMessages.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingScalarLogPropertyExists.cs">
-      <Link>WhenAssertingScalarLogPropertyExists.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingStructuredLogPropertyExists.cs">
-      <Link>WhenAssertingStructuredLogPropertyExists.cs</Link>
+    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\**\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
 </Project>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions5/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions5.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions5/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions5.csproj
@@ -26,29 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\Repro.cs">
-      <Link>Repro.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingAndSInkIsWrittenTo.cs">
-      <Link>WhenAssertingAndSInkIsWrittenTo.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventHasLevel.cs">
-      <Link>WhenAssertingLogEventHasLevel.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventsExist.cs">
-      <Link>WhenAssertingLogEventsExist.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingMessageExistsThatContainsPattern.cs">
-      <Link>WhenAssertingMessageExistsThatContainsPattern.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingPropertyValuesOnMultipleMessages.cs">
-      <Link>WhenAssertingPropertyValuesOnMultipleMessages.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingScalarLogPropertyExists.cs">
-      <Link>WhenAssertingScalarLogPropertyExists.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingStructuredLogPropertyExists.cs">
-      <Link>WhenAssertingStructuredLogPropertyExists.cs</Link>
+    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\**\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
 </Project>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj
@@ -24,31 +24,10 @@
     <ProjectReference Include="..\..\src\Serilog.Sinks.InMemory.Assertions\Serilog.Sinks.InMemory.Assertions.csproj" />
     <ProjectReference Include="..\..\src\Serilog.Sinks.InMemory\Serilog.Sinks.InMemory.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\Repro.cs">
-      <Link>Repro.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingAndSInkIsWrittenTo.cs">
-      <Link>WhenAssertingAndSInkIsWrittenTo.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventHasLevel.cs">
-      <Link>WhenAssertingLogEventHasLevel.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventsExist.cs">
-      <Link>WhenAssertingLogEventsExist.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingMessageExistsThatContainsPattern.cs">
-      <Link>WhenAssertingMessageExistsThatContainsPattern.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingPropertyValuesOnMultipleMessages.cs">
-      <Link>WhenAssertingPropertyValuesOnMultipleMessages.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingScalarLogPropertyExists.cs">
-      <Link>WhenAssertingScalarLogPropertyExists.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingStructuredLogPropertyExists.cs">
-      <Link>WhenAssertingStructuredLogPropertyExists.cs</Link>
+    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\**\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
 

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions7/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions7.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions7/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions7.csproj
@@ -26,29 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\Repro.cs">
-      <Link>Repro.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingAndSInkIsWrittenTo.cs">
-      <Link>WhenAssertingAndSInkIsWrittenTo.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventHasLevel.cs">
-      <Link>WhenAssertingLogEventHasLevel.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventsExist.cs">
-      <Link>WhenAssertingLogEventsExist.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingMessageExistsThatContainsPattern.cs">
-      <Link>WhenAssertingMessageExistsThatContainsPattern.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingPropertyValuesOnMultipleMessages.cs">
-      <Link>WhenAssertingPropertyValuesOnMultipleMessages.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingScalarLogPropertyExists.cs">
-      <Link>WhenAssertingScalarLogPropertyExists.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingStructuredLogPropertyExists.cs">
-      <Link>WhenAssertingStructuredLogPropertyExists.cs</Link>
+    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\**\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
 </Project>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions8/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions8.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions8/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions8.csproj
@@ -26,29 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\Repro.cs">
-      <Link>Repro.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingAndSInkIsWrittenTo.cs">
-      <Link>WhenAssertingAndSInkIsWrittenTo.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventHasLevel.cs">
-      <Link>WhenAssertingLogEventHasLevel.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingLogEventsExist.cs">
-      <Link>WhenAssertingLogEventsExist.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingMessageExistsThatContainsPattern.cs">
-      <Link>WhenAssertingMessageExistsThatContainsPattern.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingPropertyValuesOnMultipleMessages.cs">
-      <Link>WhenAssertingPropertyValuesOnMultipleMessages.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingScalarLogPropertyExists.cs">
-      <Link>WhenAssertingScalarLogPropertyExists.cs</Link>
-    </Compile>
-    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\WhenAssertingStructuredLogPropertyExists.cs">
-      <Link>WhenAssertingStructuredLogPropertyExists.cs</Link>
+    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\**\*.cs">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
   </ItemGroup>
 


### PR DESCRIPTION
#### Summary
This PR enhances the `Serilog.Sinks.InMemory` developer experience and assertions ecosystem:
- Makes assertion APIs more extension-friendly across multiple target assertion frameworks.
- Adds a `DebuggerTypeProxy` for `InMemorySink` to provide a cleaner debugging view.
- Performs a focused refactor of `InMemorySinkExtensions` to improve clarity and extensibility.
- Minor documentation correction in `README.md`.

#### Changes
- InMemory sink and debugging
  - Added `src/Serilog.Sinks.InMemory/InMemorySinkAdvDebugProxy.cs` and applied `[DebuggerTypeProxy]` to `InMemorySink`.
  - Updated `src/Serilog.Sinks.InMemory/InMemorySink.cs` to improve snapshot handling and thread-safety around `_logEvents` and `_logEventsSnapshot`.
- Assertion improvements
  - Updated assertion implementations/factories across versions: `FluentAssertions5/6/7/8`, `Shouldly4`, and introduced `AwesomeAssertions8/9` implementations.
  - Significant refactor in `src/Serilog.Sinks.InMemory.Assertions/InMemorySinkExtensions.cs` to better support extension scenarios.
- Abstractions and project
  - Minor adjustments in `Serilog.Sinks.InMemory.Assertions.Abstractions` including `.csproj`.
- Docs
  - `README.md` typo/wording fix.

#### Motivation and Context
- Developers extending or integrating assertions needed clearer extension points and more consistent behaviors across supported assertion libraries.
- Debugging `InMemorySink` instances was noisy; the new `DebuggerTypeProxy` streamlines inspection during tests and development.

#### Implementation Notes
- `InMemorySink` maintains an internal `_logEvents` list and `_logEventsSnapshot` with a lock (`_snapShotLock`) to keep reads fast and consistent while writes invalidate the snapshot.
- The `[DebuggerTypeProxy(typeof(InMemorySinkAdvDebugProxy))]` attribute presents key information without exposing internal implementation details.
- `InMemorySinkExtensions` refactor reduces duplication and clarifies extension points used by multiple assertion packages.

#### Breaking Changes
- None anticipated for public API. Behavior changes are additive and meant to be transparent. If consumers relied on prior debugging visualizations, the `DebuggerTypeProxy` changes the visual representation in debuggers.

#### Performance Considerations
- Snapshotting reduces repeated list allocations on reads, improving performance for test-heavy scenarios.
- Locking is scoped to snapshot invalidation and append operations only.