### PR TITLE
Add DebuggerTypeProxy for InMemorySink to simplify debugging

### DIFF
--- a/src/Serilog.Sinks.InMemory/InMemorySink.cs
+++ b/src/Serilog.Sinks.InMemory/InMemorySink.cs
@@ -1,5 +1,9 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Serilog.Core;
@@ -7,14 +11,17 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.InMemory
 {
+    [DebuggerTypeProxy(typeof(InMemorySinkAdvDebugProxy))]
     public class InMemorySink : ILogEventSink, IDisposable
     {
         private static readonly AsyncLocal<InMemorySink> LocalInstance = new AsyncLocal<InMemorySink>();
 
+        private ReadOnlyCollection<LogEvent>? _logEventsSnapshot;
         private readonly List<LogEvent> _logEvents;
         private readonly object _snapShotLock = new object();
 
-        public InMemorySink() : this(new List<LogEvent>())
+        public InMemorySink()
+            : this(new List<LogEvent>())
         {
         }
 
@@ -27,16 +34,12 @@ namespace Serilog.Sinks.InMemory
         {
             get
             {
-                if (LocalInstance.Value == null)
-                {
-                    LocalInstance.Value = new InMemorySink();
-                }
-
+                LocalInstance.Value ??= new InMemorySink();
                 return LocalInstance.Value;
             }
         }
 
-        public IEnumerable<LogEvent> LogEvents => _logEvents.AsReadOnly();
+        public IEnumerable<LogEvent> LogEvents => GetLogEvents();
 
         public void Dispose()
         {
@@ -48,17 +51,33 @@ namespace Serilog.Sinks.InMemory
             lock (_snapShotLock)
             {
                 _logEvents.Add(logEvent);
+                _logEventsSnapshot = null;
             }
+        }
+
+        private IEnumerable<LogEvent> GetLogEvents()
+        {
+            if (_logEventsSnapshot == null)
+            {
+                lock (_snapShotLock)
+                {
+                    _logEventsSnapshot ??= _logEvents.AsReadOnly();
+                }
+            }
+
+            return _logEventsSnapshot;
         }
 
         public InMemorySink Snapshot()
         {
-            lock (_snapShotLock)
-            {
-                var currentLogEvents = _logEvents.AsReadOnly().ToList();
+            var currentLogEvents = GetLogEvents().ToList();
+            return new InMemorySinkSnapshot(currentLogEvents);
+        }
 
-                return new InMemorySinkSnapshot(currentLogEvents);
-            }
+        public InMemorySink Snapshot(Func<LogEvent, bool> predicate)
+        {
+            var currentLogEvents = GetLogEvents().Where(predicate).ToList();
+            return new InMemorySinkSnapshot(currentLogEvents);
         }
     }
 }

--- a/src/Serilog.Sinks.InMemory/InMemorySinkAdvDebugProxy.cs
+++ b/src/Serilog.Sinks.InMemory/InMemorySinkAdvDebugProxy.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Events;
+
+namespace Serilog.Sinks.InMemory
+{
+    internal sealed class InMemorySinkAdvDebugProxy(InMemorySink sink)
+        : List<DebugLogEvent>(sink.LogEvents.Select(logEvent => new DebugLogEvent(logEvent)));
+
+    internal sealed class DebugLogEvent(LogEvent logEvent)
+    {
+        public LogEventLevel Level => logEvent.Level;
+        public string Message => logEvent.RenderMessage();
+
+        public string MessageTemplate => logEvent.MessageTemplate.ToString();
+
+        public IReadOnlyDictionary<string, LogEventPropertyValue> Properties => logEvent.Properties;
+
+        public Exception? Exception => logEvent.Exception;
+
+        public LogEvent OriginalLogEvent => logEvent;
+
+        public override string ToString() => Message;
+    }
+}


### PR DESCRIPTION
# Improve debug experience for InMemorySink

## Summary

This PR improves debugging of `InMemorySink` in IDE (and other debuggers) by adding a **debugger type proxy** that shows log events in a readable, expanded form. It also refines `InMemorySink` internals (cached read-only view of events, nullable, simplified `Instance` getter) and adds a **predicate overload** for `Snapshot()` to create filtered snapshots.

## Changes

### Debugger type proxy

- **`[DebuggerTypeProxy(typeof(InMemorySinkAdvDebugProxy))]`** on `InMemorySink` so that when you inspect an `InMemorySink` instance in the debugger, the value is displayed via the proxy instead of the raw type.
- **`InMemorySinkAdvDebugProxy`** – wraps the sink and exposes its log events as a `List<DebugLogEvent>` so the debugger shows a clear, expandable list of entries.
- **`DebugLogEvent`** – a debug-time view of a single log event with:
  - **Level** – `LogEventLevel`
  - **Message** – rendered message (`logEvent.RenderMessage()`)
  - **MessageTemplate** – template string
  - **Properties** – log event properties
  - **Exception** – exception if present
  - **OriginalLogEvent** – underlying `LogEvent` for deep inspection
  - **ToString()** – returns the rendered message for quick scanning in the Locals/Watch window

This makes it easier to inspect what was logged without expanding raw `LogEvent` and Serilog internals.

### InMemorySink behavior and API

- **Cached read-only view** – `LogEvents` is backed by a cached `ReadOnlyCollection<LogEvent>` (`_logEventsSnapshot`) that is invalidated whenever `Emit` is called, so repeated enumeration of `LogEvents` does not allocate and stays consistent within a “no new emit” window.
- **`Snapshot(Func<LogEvent, bool> predicate)`** – new overload that returns an `InMemorySink` snapshot containing only log events that match the given predicate (e.g. filter by level, message template, or property).
- **Nullable** – `#nullable enable` and use of `ReadOnlyCollection<LogEvent>?` for the cached snapshot.
- **Instance getter** – simplified to `LocalInstance.Value ??= new InMemorySink()`.
- **Snapshot()** – parameterless `Snapshot()` now builds the snapshot from `GetLogEvents().ToList()` (using the cached read-only view when valid).

## Benefits

- **Easier debugging** – In the debugger, expanding an `InMemorySink` shows a list of `DebugLogEvent` with Level, Message, MessageTemplate, Properties, and Exception, instead of raw collections and Serilog types.
- **Filtered snapshots** – `Snapshot(predicate)` supports assertions or inspection over a subset of events (e.g. only errors, or only a given message template) without manual filtering in test code.
- **Stable enumeration** – Cached read-only snapshot for `LogEvents` avoids repeated allocation and gives a consistent view when no new events are emitted.

## Checklist

- [ ] Solution builds with no errors or warnings.
- [ ] All tests pass.
- [ ] No breaking API changes for existing `LogEvents` or parameterless `Snapshot()` usage; new `Snapshot(predicate)` is additive.
